### PR TITLE
MetaData first pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Validation SqlDelight Migration
-        run: ./gradlew validateSqlDelightMigration
+      - name: Verify SqlDelight Migration
+        run: ./gradlew verifySqlDelightMigration
 
       - name: Build and publish
         run: ./gradlew jvmTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Validation SqlDelight Migration
+        run: ./gradlew validateSqlDelightMigration
+
       - name: Build and publish
         run: ./gradlew jvmTest
 

--- a/README.MD
+++ b/README.MD
@@ -79,12 +79,10 @@ Sqkon doesn't provide default cache busting out of the box, but it does provide 
 this if that's what you require.
 
 - `KeyValueStore.selectResult` will expose a ResultRow with a `expiresAt`, `writeAt` and `readAt`
-  fields, with this you can handle cache busting yourself. We provide `deleteWhere` and
-  `deleteExpired`
-  methods to help with this.
-- Most methods support `expiresAt`, `expiresAfter` which let you set expiry times and to return
-  fields that expire after the time passed in, we don't auto purge fields that have "expired" use
-  use `deleteExpired` to remove them.
+  fields, with this you can handle cache busting yourself.
+- Most methods support `expiresAt`, `expiresAfter` which let you set expiry times, we don't auto purge fields that have "expired" use
+  use `deleteExpired` to remove them. We track `readAt`,`writeAt` when rows are read/written too.
+- We provide `deleteWhere`, `deleteExpired`, `deleteStale`, the docs explain there differences.
 
 ### Build platform artifacts
 

--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,6 @@ SQLite and JSONB.
 ![Maven Central Version](https://img.shields.io/maven-central/v/com.mercury.sqkon/library)
 ![GitHub branch check runs](https://img.shields.io/github/check-runs/MercuryTechnologies/sqkon/main)
 
-
 ## Usage
 
 ```kotlin
@@ -67,13 +66,25 @@ dependencies {
 
 ## Project Requirements
 
-The project is built upon [SQLDelight](https://github.com/sqldelight/sqldelight) 
-and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization), these are transitive 
-dependencies, but you will not be able to use the library with applying the 
-kotlinx-serialization plugin. If you are not using kotlinx serialization, I suggest you read about it
+The project is built upon [SQLDelight](https://github.com/sqldelight/sqldelight)
+and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization), these are transitive
+dependencies, but you will not be able to use the library with applying the
+kotlinx-serialization plugin. If you are not using kotlinx serialization, I suggest you read about
+it
 here: https://github.com/Kotlin/kotlinx.serialization.
 
-```kotlin 
+## Expiry/Cache Busting
+
+Sqkon doesn't provide default cache busting out of the box, but it does provide the tools to do
+this if that's what you require.
+
+- `KeyValueStore.selectResult` will expose a ResultRow with a `expiresAt`, `writeAt` and `readAt`
+  fields, with this you can handle cache busting yourself. We provide `deleteWhere` and
+  `deleteExpired`
+  methods to help with this.
+- Most methods support `expiresAt`, `expiresAfter` which let you set expiry times and to return
+  fields that expire after the time passed in, we don't auto purge fields that have "expired" use
+  use `deleteExpired` to remove them.
 
 ### Build platform artifacts
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 
 # Maven
 GROUP=com.mercury.sqkon
-VERSION_NAME=1.0.0-alpha01
+VERSION_NAME=1.0.0-alpha02
 POM_NAME=Sqkon
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/MercuryTechnologies/sqkon/
@@ -27,6 +27,3 @@ kotlin.daemon.jvmargs=-Xmx4G
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-
-# KMP
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 androidx-monitor = "1.7.2"
 androidx-runner = "1.6.2"
 kotlin = "2.1.0"
-agp = "8.7.3"
-kotlinx-coroutines = "1.9.0"
+agp = "8.8.0"
+kotlinx-coroutines = "1.10.1"
 kotlinx-serialization = { require = "1.7.3" }
 kotlinx-datetime = "0.6.1"
 paging = "3.3.0-alpha02-0.5.1"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,4 @@
+import app.cash.sqldelight.VERSION
 import com.android.build.api.variant.HasUnitTestBuilder
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
@@ -80,6 +81,8 @@ sqldelight {
             generateAsync = true
             packageName.set("com.mercury.sqkon.db")
             schemaOutputDirectory.set(file("src/commonMain/sqldelight/databases"))
+            // We're technically using 3.45.0, but 3.38 is the latest supported version
+            dialect("app.cash.sqldelight:sqlite-3-38-dialect:$VERSION")
         }
     }
 }

--- a/library/src/androidInstrumentedTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.android.kt
+++ b/library/src/androidInstrumentedTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.android.kt
@@ -2,11 +2,9 @@ package com.mercury.sqkon.db
 
 import androidx.test.platform.app.InstrumentationRegistry
 
-actual fun createEntityQueries(): EntityQueries {
-    return createEntityQueries(
-        DriverFactory(
-            context = InstrumentationRegistry.getInstrumentation().targetContext,
-            name = null // in-memory database
-        )
+internal actual fun driverFactory(): DriverFactory {
+    return DriverFactory(
+        context = InstrumentationRegistry.getInstrumentation().targetContext,
+        name = null // in-memory database
     )
 }

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/Sqkon.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/Sqkon.android.kt
@@ -16,6 +16,8 @@ fun Sqkon(
     config: KeyValueStorage.Config = KeyValueStorage.Config(),
 ): Sqkon {
     val factory = DriverFactory(context, if (inMemory) null else "sqkon.db")
-    val entities = createEntityQueries(factory)
-    return Sqkon(entities, scope, json, config)
+    val driver = factory.createDriver()
+    val metadataQueries = MetadataQueries(driver)
+    val entityQueries = EntityQueries(driver)
+    return Sqkon(entityQueries, metadataQueries, scope, json, config)
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.delay
 import org.jetbrains.annotations.VisibleForTesting
 
 class EntityQueries(
-    driver: SqlDriver,
-) : SuspendingTransacterImpl(driver) {
+    internal val sqlDriver: SqlDriver,
+) : SuspendingTransacterImpl(sqlDriver) {
 
     // Used to slow down insert/updates for testing
     @VisibleForTesting

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -6,6 +6,8 @@ import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.delay
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import org.jetbrains.annotations.VisibleForTesting
 
 class EntityQueries(
@@ -22,51 +24,55 @@ class EntityQueries(
         driver.execute(
             identifier = identifier,
             sql = """
-            INSERT $orIgnore INTO entity (entity_name, entity_key, added_at, updated_at, expires_at, value) 
-            VALUES (?, ?, ?, ?, ?, jsonb(?))
+            INSERT $orIgnore INTO entity (
+                entity_name, entity_key, added_at, updated_at, expires_at, write_at, value
+            ) 
+            VALUES (?, ?, ?, ?, ?, ?, jsonb(?))
             """.trimIndent(),
-            parameters = 6
+            parameters = 7
         ) {
             bindString(0, entity.entity_name)
             bindString(1, entity.entity_key)
             bindLong(2, entity.added_at)
             bindLong(3, entity.updated_at)
             bindLong(4, entity.expires_at)
-            bindString(5, entity.value_)
+            bindLong(5, entity.write_at)
+            bindString(6, entity.value_)
         }.await()
         notifyQueries(identifier) { emit ->
             emit("entity")
             emit("entity_${entity.entity_name}")
         }
-        if(slowWrite) delay(100)
+        if (slowWrite) delay(100)
     }
 
     suspend fun updateEntity(
         entityName: String,
         entityKey: String,
-        updatedAt: Long,
-        expiresAt: Long?,
+        expiresAt: Instant?,
         value: String,
     ) {
+        val now = Clock.System.now()
         val identifier = identifier("update")
         driver.execute(
             identifier = identifier,
             sql = """
-                UPDATE entity SET updated_at = ?, expires_at = ?, value = jsonb(?)
+                UPDATE entity SET updated_at = ?, expires_at = ?, write_at = ?, value = jsonb(?)
                 WHERE entity_name = ? AND entity_key = ?
             """.trimMargin(), 5
         ) {
-            bindLong(0, updatedAt)
-            bindLong(1, expiresAt)
-            bindString(2, value)
-            bindString(3, entityName)
-            bindString(4, entityKey)
+            bindLong(0, now.toEpochMilliseconds())
+            bindLong(1, expiresAt?.toEpochMilliseconds())
+            bindLong(2, now.toEpochMilliseconds())
+            bindString(3, value)
+            bindString(4, entityName)
+            bindString(5, entityKey)
         }.await()
         notifyQueries(identifier) { emit ->
             emit("entity")
             emit("entity_${entityName}")
         }
-        if(slowWrite) delay(100)
+        if (slowWrite) delay(100)
     }
 
     fun select(
@@ -76,6 +82,7 @@ class EntityQueries(
         orderBy: List<OrderBy<*>> = emptyList(),
         limit: Long? = null,
         offset: Long? = null,
+        expiresAt: Instant? = null,
     ): Query<Entity> = SelectQuery(
         entityName = entityName,
         entityKeys = entityKeys,
@@ -83,6 +90,7 @@ class EntityQueries(
         orderBy = orderBy,
         limit = limit,
         offset = offset,
+        expiresAt = expiresAt,
     ) { cursor ->
         Entity(
             entity_name = cursor.getString(0)!!,
@@ -90,7 +98,9 @@ class EntityQueries(
             added_at = cursor.getLong(2)!!,
             updated_at = cursor.getLong(3)!!,
             expires_at = cursor.getLong(4),
-            value_ = cursor.getString(5)!!,
+            read_at = cursor.getLong(5),
+            write_at = cursor.getLong(6)!!,
+            value_ = cursor.getString(7)!!,
         )
     }
 
@@ -101,6 +111,7 @@ class EntityQueries(
         private val orderBy: List<OrderBy<*>>,
         private val limit: Long? = null,
         private val offset: Long? = null,
+        private val expiresAt: Instant? = null,
         mapper: (SqlCursor) -> Entity,
     ) : Query<Entity>(mapper) {
 
@@ -119,6 +130,13 @@ class EntityQueries(
                         where = "entity_name = ?",
                         parameters = 1,
                         bindArgs = { bindString(entityName) },
+                    )
+                )
+                if (expiresAt != null) add(
+                    SqlQuery(
+                        where = "expires_at IS NULL OR expires_at >= ?",
+                        parameters = 1,
+                        bindArgs = { bindLong(expiresAt.toEpochMilliseconds()) },
                     )
                 )
                 when (entityKeys?.size) {
@@ -151,7 +169,8 @@ class EntityQueries(
             )
             val sql = """
                 SELECT DISTINCT entity.entity_name, entity.entity_key, entity.added_at, 
-                entity.updated_at, entity.expires_at, json_extract(entity.value, '$') value
+                entity.updated_at, entity.expires_at, entity.read_at, entity.write_at, 
+                json_extract(entity.value, '$') value
                 FROM entity${queries.buildFrom()} ${queries.buildWhere()} ${queries.buildOrderBy()}
                 ${limit?.let { "LIMIT ?" } ?: ""} ${offset?.let { "OFFSET ?" } ?: ""}
             """.trimIndent().replace('\n', ' ')
@@ -225,13 +244,15 @@ class EntityQueries(
     fun count(
         entityName: String,
         where: Where<*>? = null,
-    ): Query<Int> = CountQuery(entityName, where) { cursor ->
+        expiresAfter: Instant? = null
+    ): Query<Int> = CountQuery(entityName, where, expiresAfter) { cursor ->
         cursor.getLong(0)!!.toInt()
     }
 
     private inner class CountQuery<out T : Any>(
         private val entityName: String,
         private val where: Where<*>? = null,
+        private val expiresAfter: Instant? = null,
         mapper: (SqlCursor) -> T,
     ) : Query<T>(mapper) {
 
@@ -250,6 +271,13 @@ class EntityQueries(
                     parameters = 1,
                     bindArgs = { bindString(entityName) }
                 ))
+                if (expiresAfter != null) add(
+                    SqlQuery(
+                        where = "expires_at IS NULL OR expires_at >= ?",
+                        parameters = 1,
+                        bindArgs = { bindLong(expiresAfter.toEpochMilliseconds()) }
+                    )
+                )
                 addAll(listOfNotNull(where?.toSqlQuery(increment = 1)))
             }
             val identifier: Int = identifier("count", queries.identifier().toString())

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
@@ -12,6 +12,6 @@ internal fun MetadataQueries(driver: SqlDriver): MetadataQueries {
         metadataAdapter = Metadata.Adapter(
             lastWriteAtAdapter = InstantColumnAdapter(),
             lastReadAtAdapter = InstantColumnAdapter(),
-        )
+        ),
     )
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
@@ -1,0 +1,17 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.db.SqlDriver
+import com.mercury.sqkon.db.adapters.InstantColumnAdapter
+
+/**
+ * Factory method to create [MetadataQueries] instance
+ */
+internal fun MetadataQueries(driver: SqlDriver): MetadataQueries {
+    return MetadataQueries(
+        driver = driver,
+        metadataAdapter = Metadata.Adapter(
+            lastWriteAtAdapter = InstantColumnAdapter(),
+            lastReadAtAdapter = InstantColumnAdapter(),
+        )
+    )
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/ResultRow.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/ResultRow.kt
@@ -1,0 +1,21 @@
+package com.mercury.sqkon.db
+
+import kotlinx.datetime.Instant
+
+data class ResultRow<T : Any>(
+    val addedAt: Instant,
+    val updatedAt: Instant,
+    val expiresAt: Instant?,
+    val readAt: Instant?,
+    val writeAt: Instant,
+    val value: T,
+) {
+    internal constructor(entity: Entity, value: T) : this(
+        addedAt = Instant.fromEpochMilliseconds(entity.added_at),
+        updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
+        expiresAt = entity.expires_at?.let { Instant.fromEpochMilliseconds(it) },
+        readAt = entity.read_at?.let { Instant.fromEpochMilliseconds(it) },
+        writeAt = Instant.fromEpochMilliseconds(entity.write_at),
+        value = value,
+    )
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.Json
  */
 class Sqkon internal constructor(
     @PublishedApi internal val entityQueries: EntityQueries,
+    @PublishedApi internal val metadataQueries: MetadataQueries,
     @PublishedApi internal val scope: CoroutineScope,
     json: Json = SqkonJson {},
     @PublishedApi
@@ -46,7 +47,7 @@ class Sqkon internal constructor(
         name: String,
         config: KeyValueStorage.Config = this.config,
     ): KeyValueStorage<T> {
-        return keyValueStorage<T>(name, entityQueries, scope, serializer, config)
+        return keyValueStorage<T>(name, entityQueries, metadataQueries, scope, serializer, config)
     }
 
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.kt
@@ -5,8 +5,3 @@ import app.cash.sqldelight.db.SqlDriver
 internal expect class DriverFactory {
     fun createDriver(): SqlDriver
 }
-
-internal fun createEntityQueries(driverFactory: DriverFactory): EntityQueries {
-    val driver = driverFactory.createDriver()
-    return EntityQueries(driver)
-}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/adapters/InstantColumnAdapter.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/adapters/InstantColumnAdapter.kt
@@ -1,0 +1,14 @@
+package com.mercury.sqkon.db.adapters
+
+import app.cash.sqldelight.ColumnAdapter
+import kotlinx.datetime.Instant
+
+internal class InstantColumnAdapter : ColumnAdapter<Instant, Long> {
+    override fun decode(databaseValue: Long): Instant {
+        return Instant.fromEpochMilliseconds(databaseValue)
+    }
+
+    override fun encode(value: Instant): Long {
+        return value.toEpochMilliseconds()
+    }
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/RequestHash.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/RequestHash.kt
@@ -1,0 +1,8 @@
+package com.mercury.sqkon.db.utils
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+internal class RequestHash(val hash: Int) : AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<RequestHash>
+}

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq
@@ -9,10 +9,21 @@ CREATE TABLE entity (
     updated_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- UTC timestamp in milliseconds
     expires_at INTEGER,
+    -- UTC timestamp in milliseconds
+    read_at INTEGER,
+    -- UTC timestamp in milliseconds
+    write_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- JSONB Blob use jsonb_ operators
     value BLOB AS String NOT NULL,
     PRIMARY KEY (entity_name, entity_key)
 );
+
+-- Index read_at
+CREATE INDEX idx_entity_read_at ON entity (read_at);
+-- Index write_at
+CREATE INDEX idx_entity_write_at ON entity (write_at);
+-- Index expires_at
+CREATE INDEX idx_entity_expires_at ON entity (expires_at);
 
 -- insertEntity:
 -- INSERT INTO entity VALUES ?;

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq
@@ -9,12 +9,12 @@ CREATE TABLE entity (
     updated_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
     -- UTC timestamp in milliseconds
     expires_at INTEGER,
+    -- JSONB Blob use jsonb_ operators
+    value BLOB AS String NOT NULL,
     -- UTC timestamp in milliseconds
     read_at INTEGER,
     -- UTC timestamp in milliseconds
     write_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    -- JSONB Blob use jsonb_ operators
-    value BLOB AS String NOT NULL,
     PRIMARY KEY (entity_name, entity_key)
 );
 

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
@@ -17,6 +17,10 @@ INSERT INTO metadata (entity_name, lastReadAt)
         UPDATE SET lastReadAt = :lastReadAt
         WHERE entity_name = :entity_name;
 
+upsertReadForEntities:
+UPDATE entity SET read_at = CURRENT_TIMESTAMP
+    WHERE entity_name = :entity_name AND entity_key IN :entity_keys;
+
 upsertWrite:
 INSERT INTO metadata (entity_name, lastWriteAt)
     VALUES (:entity_name, :lastWriteAt)
@@ -25,3 +29,6 @@ INSERT INTO metadata (entity_name, lastWriteAt)
         UPDATE SET lastWriteAt = :lastWriteAt
         WHERE entity_name = :entity_name;
 
+purgeExpires:
+DELETE FROM entity
+    WHERE entity_name = :entity_name AND expires_at IS NOT NULL AND expires_at < :expiresAfter;

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
@@ -1,0 +1,20 @@
+import kotlinx.datetime.Instant;
+
+CREATE TABLE metadata (
+    entity_name TEXT NOT NULL PRIMARY KEY,
+    lastReadAt INTEGER AS Instant,
+    lastWriteAt INTEGER AS Instant
+);
+
+selectByEntityName:
+SELECT * FROM metadata WHERE entity_name = ?;
+
+upsertRead {
+    UPDATE metadata SET lastReadAt = :lastReadAt WHERE entity_name = :entity_name;
+    INSERT OR IGNORE INTO metadata (entity_name, lastReadAt) VALUES (:entity_name, :lastReadAt);
+}
+
+upsertWrite {
+    UPDATE metadata SET lastWriteAt = :lastWriteAt WHERE entity_name = :entity_name;
+    INSERT OR IGNORE INTO metadata (entity_name, lastWriteAt) VALUES (:entity_name, :lastWriteAt);
+}

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
@@ -9,12 +9,19 @@ CREATE TABLE metadata (
 selectByEntityName:
 SELECT * FROM metadata WHERE entity_name = ?;
 
-upsertRead {
-    UPDATE metadata SET lastReadAt = :lastReadAt WHERE entity_name = :entity_name;
-    INSERT OR IGNORE INTO metadata (entity_name, lastReadAt) VALUES (:entity_name, :lastReadAt);
-}
+upsertRead:
+INSERT INTO metadata (entity_name, lastReadAt)
+    VALUES (:entity_name, :lastReadAt)
+    ON CONFLICT(entity_name)
+    DO
+        UPDATE SET lastReadAt = :lastReadAt
+        WHERE entity_name = :entity_name;
 
-upsertWrite {
-    UPDATE metadata SET lastWriteAt = :lastWriteAt WHERE entity_name = :entity_name;
-    INSERT OR IGNORE INTO metadata (entity_name, lastWriteAt) VALUES (:entity_name, :lastWriteAt);
-}
+upsertWrite:
+INSERT INTO metadata (entity_name, lastWriteAt)
+    VALUES (:entity_name, :lastWriteAt)
+    ON CONFLICT(entity_name)
+    DO
+        UPDATE SET lastWriteAt = :lastWriteAt
+        WHERE entity_name = :entity_name;
+

--- a/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
+++ b/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq
@@ -17,8 +17,8 @@ INSERT INTO metadata (entity_name, lastReadAt)
         UPDATE SET lastReadAt = :lastReadAt
         WHERE entity_name = :entity_name;
 
-upsertReadForEntities:
-UPDATE entity SET read_at = CURRENT_TIMESTAMP
+updateReadForEntities:
+UPDATE entity SET read_at = :readAt
     WHERE entity_name = :entity_name AND entity_key IN :entity_keys;
 
 upsertWrite:
@@ -32,3 +32,8 @@ INSERT INTO metadata (entity_name, lastWriteAt)
 purgeExpires:
 DELETE FROM entity
     WHERE entity_name = :entity_name AND expires_at IS NOT NULL AND expires_at < :expiresAfter;
+
+purgeStale:
+DELETE FROM entity
+    WHERE entity_name = :entity_name
+    AND write_at < :instant AND (read_at IS NULL OR read_at < :instant);

--- a/library/src/commonMain/sqldelight/migrations/1.sqm
+++ b/library/src/commonMain/sqldelight/migrations/1.sqm
@@ -5,3 +5,13 @@ CREATE TABLE metadata (
     lastReadAt INTEGER AS Instant,
     lastWriteAt INTEGER AS Instant
 );
+
+ALTER TABLE entity ADD COLUMN read_at INTEGER;
+ALTER TABLE entity ADD COLUMN write_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Index read_at
+CREATE INDEX idx_entity_read_at ON entity (read_at);
+-- Index write_at
+CREATE INDEX idx_entity_write_at ON entity (write_at);
+-- Index expires_at
+CREATE INDEX idx_entity_expires_at ON entity (expires_at);

--- a/library/src/commonMain/sqldelight/migrations/1.sqm
+++ b/library/src/commonMain/sqldelight/migrations/1.sqm
@@ -1,0 +1,7 @@
+import kotlinx.datetime.Instant;
+
+CREATE TABLE metadata (
+    entity_name TEXT NOT NULL PRIMARY KEY,
+    lastReadAt INTEGER AS Instant,
+    lastWriteAt INTEGER AS Instant
+);

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/DeserializationTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/DeserializationTest.kt
@@ -18,18 +18,22 @@ import kotlin.test.fail
 class DeserializationTest {
 
     private val mainScope = MainScope()
-    private val entityQueries = createEntityQueries()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(
-        "test-object", entityQueries, mainScope
+        "test-object", entityQueries, metadataQueries, mainScope
     )
     private val testObjectStorageError = keyValueStorage<UnSerializable>(
-        "test-object", entityQueries, mainScope, config = KeyValueStorage.Config(
+        "test-object", entityQueries, metadataQueries, mainScope,
+        config = KeyValueStorage.Config(
             deserializePolicy = KeyValueStorage.Config.DeserializePolicy.ERROR // default
         )
     )
 
     private val testObjectStorageDelete = keyValueStorage<UnSerializable>(
-        "test-object", entityQueries, mainScope, config = KeyValueStorage.Config(
+        "test-object", entityQueries, metadataQueries, mainScope,
+        config = KeyValueStorage.Config(
             deserializePolicy = KeyValueStorage.Config.DeserializePolicy.DELETE
         )
     )

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
@@ -1,0 +1,108 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+
+class KeyValueStorageExpiresTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val testObjectStorage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun insertAll() = runTest {
+        val now = Clock.System.now()
+        val expected = (0..10).map { TestObject() }
+            .associateBy { it.id }
+            .toSortedMap()
+        testObjectStorage.insertAll(expected, expiresAt = now.minus(1.milliseconds))
+        val actual = testObjectStorage.selectAll(expiresAfter = now).first()
+        assertEquals(0, actual.size)
+    }
+
+    @Test
+    fun update() = runTest {
+        val now = Clock.System.now()
+        val inserted = TestObject()
+        testObjectStorage.insert(inserted.id, inserted, expiresAt = now.minus(1.milliseconds))
+        val actualInserted = testObjectStorage.selectAll(expiresAfter = now).first()
+        assertEquals(0, actualInserted.size)
+        // update with new expires
+        testObjectStorage.update(inserted.id, inserted, expiresAt = now.plus(1.milliseconds))
+        val actualUpdated = testObjectStorage.selectAll(expiresAfter = now).first()
+        assertEquals(1, actualUpdated.size)
+    }
+
+    @Test
+    fun upsert() = runTest {
+        val now = Clock.System.now()
+        val inserted = TestObject()
+        testObjectStorage.upsert(inserted.id, inserted, expiresAt = now.minus(1.milliseconds))
+        val actualInserted = testObjectStorage.selectAll(expiresAfter = now).first()
+        assertEquals(0, actualInserted.size)
+        testObjectStorage.upsert(inserted.id, inserted, expiresAt = now.plus(1.milliseconds))
+        val actualUpdated = testObjectStorage.selectAll(expiresAfter = now).first()
+        assertEquals(1, actualUpdated.size)
+    }
+
+    @Test
+    fun deleteExpired() = runTest {
+        val now = Clock.System.now()
+        val expected = (0..10).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected, expiresAt = now.minus(1.milliseconds))
+        val actual = testObjectStorage.selectAll().first() // all results
+        assertEquals(expected.size, actual.size)
+
+        testObjectStorage.deleteExpired(expiresAfter = now)
+        // No expires to return everything
+        val actualAfterDelete = testObjectStorage.selectAll().first()
+        assertEquals(0, actualAfterDelete.size)
+    }
+
+    @Test
+    fun delete_byEntityId() = runTest {
+        val expected = (0..10).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+        val actual = testObjectStorage.selectAll().first()
+        assertEquals(expected.size, actual.size)
+
+        val key = expected.keys.toList()[5]
+        testObjectStorage.delete(
+            where = TestObject::id eq key
+        )
+        val actualAfterDelete = testObjectStorage.selectAll().first()
+        assertEquals(expected.size - 1, actualAfterDelete.size)
+    }
+
+    @Test
+    fun count() = runTest {
+        val now = Clock.System.now()
+        val empty = testObjectStorage.count().first()
+        assertEquals(expected = 0, empty)
+
+        val expected = (0..10).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected, expiresAt = now.minus(1.milliseconds))
+        val zero = testObjectStorage.count(expiresAfter = now).first()
+        assertEquals(0, zero)
+        val ten = testObjectStorage.count(expiresAfter = now.minus(1.milliseconds)).first()
+        assertEquals(expected.size, ten)
+    }
+
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageStaleTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageStaleTest.kt
@@ -1,0 +1,89 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.After
+import org.junit.Test
+import java.lang.Thread.sleep
+import kotlin.test.assertEquals
+
+class KeyValueStorageStaleTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val testObjectStorage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun insertAll_staleInPast() = runTest {
+        val now = Clock.System.now()
+        val expected = (0..10).map { TestObject() }
+            .associateBy { it.id }
+            .toSortedMap()
+        testObjectStorage.insertAll(expected)
+        // Clean up older than now
+        testObjectStorage.deleteStale(instant = now)
+        val actualAfterDelete = testObjectStorage.selectAll().first()
+        assertEquals(expected.size, actualAfterDelete.size)
+    }
+
+    @Test
+    fun insertAll_staleWrite() = runTest {
+        val expected = (0..10).map { TestObject() }
+            .associateBy { it.id }
+            .toSortedMap()
+        testObjectStorage.insertAll(expected)
+        sleep(1)
+        val now = Clock.System.now()
+        // Clean up older than now
+        testObjectStorage.deleteStale(instant = now)
+        val actualAfterDelete = testObjectStorage.selectAll().first()
+        assertEquals(0, actualAfterDelete.size)
+    }
+
+    @Test
+    fun insertAll_readInPast() = runTest {
+        val expected = (0..10).map { TestObject() }
+            .associateBy { it.id }
+            .toSortedMap()
+        testObjectStorage.insertAll(expected)
+        testObjectStorage.selectAll().first()
+        sleep(10)
+        val now = Clock.System.now()
+        // write again so read is in the past
+        testObjectStorage.updateAll(expected)
+        // Read in the past write is after now
+        testObjectStorage.deleteStale(instant = now)
+        val actualAfterDelete = testObjectStorage.selectAll().first()
+        assertEquals(expected.size, actualAfterDelete.size)
+    }
+
+    @Test
+    fun insertAll_staleRead() = runTest {
+        val expected = (0..10).map { TestObject() }
+            .associateBy { it.id }
+            .toSortedMap()
+        testObjectStorage.insertAll(expected)
+        sleep(10)
+        testObjectStorage.selectAll().first()
+        sleep(10)
+        val now = Clock.System.now()
+        // Clean write and read are in the past
+        testObjectStorage.deleteStale(instant = now)
+        val actualAfterDelete = testObjectStorage.selectResult().first()
+        assertEquals(0, actualAfterDelete.size)
+    }
+
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
@@ -19,9 +19,11 @@ import kotlin.time.Duration.Companion.seconds
 class KeyValueStorageTest {
 
     private val mainScope = MainScope()
-    private val entityQueries = createEntityQueries()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(
-        "test-object", entityQueries, mainScope
+        "test-object", entityQueries, metadataQueries, mainScope
     )
 
     @After

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
@@ -1,6 +1,7 @@
 package com.mercury.sqkon.db
 
 import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.mercury.sqkon.TestObject
 import com.mercury.sqkon.TestObjectChild
 import com.mercury.sqkon.until
@@ -379,55 +380,52 @@ class KeyValueStorageTest {
 
     @Test
     fun selectAllFlow_flowUpdatesOnUpdate() = runTest {
-        val expected = (0..10).map { TestObject() }
-            .associateBy { it.id }
-            .toSortedMap()
-        testObjectStorage.insertAll(expected)
-        val results: MutableList<List<TestObject>> = mutableListOf()
-        backgroundScope.launch {
-            testObjectStorage.selectAll(
+        turbineScope {
+            val expected = (0..10).map { TestObject() }
+                .associateBy { it.id }
+                .toSortedMap()
+            testObjectStorage.insertAll(expected)
+            val results = testObjectStorage.selectAll(
                 orderBy = listOf(OrderBy(TestObject::id, direction = OrderDirection.ASC))
-            ).collect { results.add(it) }
+            ).testIn(backgroundScope)
+
+            val first = results.awaitItem()
+            assertEquals(expected.size, first.size)
+
+            val updated = expected.values.toList()[5].copy(
+                name = "Updated Name",
+                value = 12345,
+                description = "Updated Description",
+                child = expected.values.toList()[5].child.copy(updatedAt = Clock.System.now())
+            )
+            testObjectStorage.update(updated.id, updated)
+            val second = results.awaitItem()
+            assertEquals(expected.size, second.size)
+            assertEquals(updated, second[5])
         }
-
-        until { results.size == 1 }
-        assertEquals(expected.size, results.first().size)
-
-        val updated = expected.values.toList()[5].copy(
-            name = "Updated Name",
-            value = 12345,
-            description = "Updated Description",
-            child = expected.values.toList()[5].child.copy(updatedAt = Clock.System.now())
-        )
-        testObjectStorage.update(updated.id, updated)
-        until { results.size == 2 }
-
-        assertEquals(expected.size, results[1].size)
-        assertEquals(updated, results[1][5])
     }
 
     @Test
     fun selectAllFlow_flowUpdatesOnDelete() = runTest {
-        val expected = (0..10).map { TestObject() }
-            .associateBy { it.id }
-            .toSortedMap()
-        testObjectStorage.insertAll(expected)
-        val results: MutableList<List<TestObject>> = mutableListOf()
-        backgroundScope.launch {
-            testObjectStorage.selectAll(
+        turbineScope {
+            val expected = (0..10).map { TestObject() }
+                .associateBy { it.id }
+                .toSortedMap()
+            testObjectStorage.insertAll(expected)
+            val results = testObjectStorage.selectAll(
                 orderBy = listOf(OrderBy(TestObject::id, direction = OrderDirection.ASC))
-            ).collect { results.add(it) }
+            ).testIn(backgroundScope)
+
+            val first = results.awaitItem()
+            assertEquals(expected.size, first.size)
+
+            val key = expected.keys.toList()[5]
+            testObjectStorage.deleteByKey(key)
+            val second = results.awaitItem()
+            assertEquals(expected.size - 1, second.size)
         }
-
-        until { results.size == 1 }
-        assertEquals(expected.size, results.first().size)
-
-        val key = expected.keys.toList()[5]
-        testObjectStorage.deleteByKey(key)
-        until { results.size == 2 }
-
-        assertEquals(expected.size - 1, results[1].size)
     }
+
 
     @Test
     fun selectCount_flowUpdatesOnChange() = runTest {

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
@@ -1,0 +1,89 @@
+package com.mercury.sqkon.db
+
+import app.cash.turbine.test
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import org.junit.After
+import org.junit.Test
+import java.lang.Thread.sleep
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MetadataTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val testObjectStorage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun updateWrite_onInsert() = runTest {
+        val expected = (1..20).map { _ -> TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+
+        testObjectStorage.metadata().test {
+            sleep(1)
+            val now = Clock.System.now()
+            awaitItem().also {
+                assertEquals("test-object", it.entity_name)
+                assertNotNull(it.lastWriteAt)
+                assertNull(it.lastReadAt)
+                assertTrue { it.lastWriteAt!! <= now }
+            }
+        }
+    }
+
+    @Test
+    fun updateWrite_onUpdate() = runTest {
+        val expected = (1..20).map { _ -> TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+
+        testObjectStorage.metadata().test {
+            val now = Clock.System.now()
+            sleep(2)
+            awaitItem()
+            testObjectStorage.updateAll(expected)
+            awaitItem().also {
+                assertEquals("test-object", it.entity_name)
+                assertNotNull(it.lastWriteAt)
+                assertNull(it.lastReadAt)
+                assertTrue { it.lastWriteAt!! > now }
+            }
+        }
+    }
+
+    @Test
+    fun updateRead_onSelect() = runTest {
+        val expected = (1..20).map { _ -> TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+        sleep(1)
+        val now = Clock.System.now()
+        sleep(2)
+        testObjectStorage.metadata().test {
+            awaitItem()
+            testObjectStorage.selectAll().first()
+            awaitItem().also {
+                assertEquals("test-object", it.entity_name)
+                assertNotNull(it.lastWriteAt)
+                assertNotNull(it.lastReadAt)
+                assertTrue { it.lastWriteAt!! <= now }
+                assertTrue { it.lastReadAt!! > now }
+            }
+        }
+    }
+
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingTest.kt
@@ -22,9 +22,11 @@ import kotlin.test.assertNull
 class OffsetPagingTest {
 
     private val mainScope = MainScope()
-    private val entityQueries = createEntityQueries()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(
-        "test-object", entityQueries, mainScope
+        "test-object", entityQueries, metadataQueries, mainScope
     )
 
     @After

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.kt
@@ -1,3 +1,3 @@
 package com.mercury.sqkon.db
 
-expect fun createEntityQueries(): EntityQueries
+internal expect fun driverFactory(): DriverFactory

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/Sqkon.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/Sqkon.jvm.kt
@@ -12,6 +12,8 @@ fun Sqkon(
     config: KeyValueStorage.Config = KeyValueStorage.Config(),
 ): Sqkon {
     val factory = DriverFactory(jdbcUrl)
-    val entities = createEntityQueries(factory)
-    return Sqkon(entities, scope, json)
+    val driver = factory.createDriver()
+    val metadataQueries = MetadataQueries(driver)
+    val entityQueries = EntityQueries(driver)
+    return Sqkon(entityQueries, metadataQueries, scope, json, config)
 }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.jvm.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.jvm.kt
@@ -1,6 +1,6 @@
 package com.mercury.sqkon.db
 
 
-actual fun createEntityQueries(): EntityQueries {
-    return createEntityQueries(DriverFactory())
+internal actual fun driverFactory(): DriverFactory {
+    return DriverFactory()
 }


### PR DESCRIPTION
Fix for https://github.com/MercuryTechnologies/sqkon/issues/4

Key New methods:
- `deleteExpired`
- `deleteStale`
- `selectResult`
- Added expiresAt/expiresAfter parameters to methods
- Added metadata() for table level read/write details

This pull request includes various updates and improvements to the `library` project, including changes to the SQLDelight integration, addition of cache busting features, and updates to dependencies. The most important changes are grouped by their themes below:

### SQLDelight Integration and Database Schema Updates:
* Added `verifySqlDelightMigration` step to the CI workflow to ensure SQLDelight migrations are verified. (`.github/workflows/ci.yml`)
* Updated `EntityQueries` to include new fields `write_at` and `read_at` for better tracking of entity states. (`library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt`) [[1]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdL25-R40) [[2]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdL47-R69) [[3]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdR85-R103) [[4]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdR114) [[5]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdR135-R141) [[6]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdL154-R173) [[7]](diffhunk://#diff-35ad778381dd4bc287f056257f8f6c3bde15455a65ef979a143544322e872ffdL228-R255)

### Cache Busting and Expiry Features:
* Introduced cache busting tools in `README.MD` to handle expiry and stale data. (`README.MD`)
* Enhanced `KeyValueStorage` to support expiry times for entities and added methods to manage expired data. (`library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt`) [[1]](diffhunk://#diff-59425f24b5e8996ede8af868901f7d7e27da81b3dff87eb0225ba6b0335ec04bR41-L37) [[2]](diffhunk://#diff-59425f24b5e8996ede8af868901f7d7e27da81b3dff87eb0225ba6b0335ec04bL49-R93) [[3]](diffhunk://#diff-59425f24b5e8996ede8af868901f7d7e27da81b3dff87eb0225ba6b0335ec04bR103-R180)

### Dependency and Version Updates:
* Updated project version to `1.0.0-alpha02` and upgraded dependencies such as `kotlinx-coroutines` and `agp`. (`gradle.properties`, `gradle/libs.versions.toml`) [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L10-R10) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL5-R6)
* Imported `app.cash.sqldelight.VERSION` in `build.gradle.kts` and specified the SQLite dialect version. (`library/build.gradle.kts`) [[1]](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dR1) [[2]](diffhunk://#diff-99c7344903488f04b710c22920f5f6fc7dfc61ac86e7bf6e7d932c603e3aad6dR84-R85)

### Code Refactoring and Cleanup:
* Refactored `Sqkon` initialization to separate `metadataQueries` and `entityQueries`. (`library/src/androidMain/kotlin/com/mercury/sqkon/db/Sqkon.android.kt`)
* Removed unused properties and cleaned up `gradle.properties`. (`gradle.properties`)

### Documentation and Readability Improvements:
* Minor formatting and readability improvements in `README.MD`. (`README.MD`)

These changes collectively enhance the functionality, performance, and maintainability of the project.