### PR TITLE
Update AndroidxSqlite + Read/Write Dispatchers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 # Maven
 GROUP=com.mercury.sqkon
-VERSION_NAME=1.0.0-alpha10
+VERSION_NAME=1.0.0-alpha11
 POM_NAME=Sqkon
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/MercuryTechnologies/sqkon/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 androidx-monitor = "1.7.2"
 androidx-runner = "1.6.2"
-androidx-sqlite = "2.5.0-rc03"
+androidx-sqlite = "2.5.0"
 kotlin = "2.1.20"
 agp = "8.9.1"
-kotlinx-coroutines = "1.10.1"
-kotlinx-serialization = { require = "1.8.0" }
+kotlinx-coroutines = "1.10.2"
+kotlinx-serialization = { require = "1.8.1" }
 kotlinx-datetime = "0.6.2"
 paging = "3.3.0-alpha02-0.5.1"
 sqlDelight = "2.0.2"
@@ -24,7 +24,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 paging-common = { module = "app.cash.paging:paging-common", version.ref = "paging" }
 paging-testing = { module = "app.cash.paging:paging-testing", version.ref = "paging" }
-sqlDelight-androidx-driver = { module = "com.eygraber:sqldelight-androidx-driver", version = "0.0.9" }
+sqlDelight-androidx-driver = { module = "com.eygraber:sqldelight-androidx-driver", version = "0.0.10" }
 sqlDelight-driver-sqlite = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 sqlDelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqlDelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/Sqkon.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/Sqkon.android.kt
@@ -19,5 +19,9 @@ fun Sqkon(
     val driver = factory.createDriver()
     val metadataQueries = MetadataQueries(driver)
     val entityQueries = EntityQueries(driver)
-    return Sqkon(entityQueries, metadataQueries, scope, json, config)
+    return Sqkon(
+        entityQueries, metadataQueries, scope, json, config,
+        readDispatcher = dbReadDispatcher,
+        writeDispatcher = dbWriteDispatcher,
+    )
 }

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
@@ -1,12 +1,22 @@
 package com.mercury.sqkon.db
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Resources
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
+import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDriver
 import com.eygraber.sqldelight.androidx.driver.File
+import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
+import com.eygraber.sqldelight.androidx.driver.SqliteSync
+import kotlinx.coroutines.Dispatchers
+
+internal val connectionPoolSize by lazy { getWALConnectionPoolSize() }
+internal val dbWriteDispatcher by lazy { Dispatchers.IO.limitedParallelism(1) }
+internal val dbReadDispatcher by lazy { Dispatchers.IO.limitedParallelism(connectionPoolSize) }
 
 /**
  * @param name The name of the database to open or create. If null, an in-memory database will
@@ -23,7 +33,24 @@ internal actual class DriverFactory(
                 null -> AndroidxSqliteDatabaseType.Memory
                 else -> AndroidxSqliteDatabaseType.File(context = context, name = name)
             },
-            schema = SqkonDatabase.Schema.synchronous()
+            schema = SqkonDatabase.Schema.synchronous(),
+            configuration = AndroidxSqliteConfiguration(
+                journalMode = SqliteJournalMode.WAL,
+                sync = SqliteSync.Normal,
+                readerConnectionsCount = connectionPoolSize,
+            )
         )
+    }
+}
+
+
+@SuppressLint("DiscouragedApi")
+private fun getWALConnectionPoolSize(): Int {
+    val resources = Resources.getSystem()
+    val resId = resources.getIdentifier("db_connection_pool_size", "integer", "android")
+    return if (resId != 0) {
+        resources.getInteger(resId)
+    } else {
+        4 // Default is 4 readers as per AndroidxSqliteConfiguration
     }
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
@@ -2,7 +2,9 @@ package com.mercury.sqkon.db
 
 import com.mercury.sqkon.db.serialization.KotlinSqkonSerializer
 import com.mercury.sqkon.db.serialization.SqkonJson
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
 
 /**
@@ -29,6 +31,10 @@ class Sqkon internal constructor(
     json: Json = SqkonJson {},
     @PublishedApi
     internal val config: KeyValueStorage.Config = KeyValueStorage.Config(),
+    @PublishedApi internal val readDispatcher: CoroutineDispatcher =
+        Dispatchers.Default.limitedParallelism(4),
+    @PublishedApi internal val writeDispatcher: CoroutineDispatcher =
+        Dispatchers.Default.limitedParallelism(1),
 ) {
 
     @PublishedApi
@@ -47,7 +53,11 @@ class Sqkon internal constructor(
         name: String,
         config: KeyValueStorage.Config = this.config,
     ): KeyValueStorage<T> {
-        return keyValueStorage<T>(name, entityQueries, metadataQueries, scope, serializer, config)
+        return keyValueStorage<T>(
+            name, entityQueries, metadataQueries, scope, serializer, config,
+            readDispatcher = readDispatcher,
+            writeDispatcher = writeDispatcher,
+        )
     }
 
 }

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/Sqkon.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/Sqkon.jvm.kt
@@ -15,5 +15,9 @@ fun Sqkon(
     val driver = factory.createDriver()
     val metadataQueries = MetadataQueries(driver)
     val entityQueries = EntityQueries(driver)
-    return Sqkon(entityQueries, metadataQueries, scope, json, config)
+    return Sqkon(
+        entityQueries, metadataQueries, scope, json, config,
+        readDispatcher = dbReadDispatcher,
+        writeDispatcher = dbWriteDispatcher,
+    )
 }

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
@@ -3,8 +3,16 @@ package com.mercury.sqkon.db
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
+import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDriver
+import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
+import com.eygraber.sqldelight.androidx.driver.SqliteSync
+import kotlinx.coroutines.Dispatchers
+
+internal const val connectionPoolSize = 4 // Default is 4 as per AndroidxSqliteConfiguration
+internal val dbWriteDispatcher by lazy { Dispatchers.IO.limitedParallelism(1) }
+internal val dbReadDispatcher by lazy { Dispatchers.IO.limitedParallelism(connectionPoolSize) }
 
 internal actual class DriverFactory(
     private val databaseType: AndroidxSqliteDatabaseType = AndroidxSqliteDatabaseType.Memory,
@@ -15,6 +23,11 @@ internal actual class DriverFactory(
             driver = BundledSQLiteDriver(),
             databaseType = databaseType,
             schema = SqkonDatabase.Schema.synchronous(),
+            configuration = AndroidxSqliteConfiguration(
+                journalMode = SqliteJournalMode.WAL,
+                sync = SqliteSync.Normal,
+                readerConnectionsCount = connectionPoolSize,
+            )
         )
     }
 


### PR DESCRIPTION
- Update to AndroidxSqlite 2.5.0 release
- Implement Read and Write Dispatchers to support connection pooling and write queuing
- Will Run in WAL mode with 4 readers by default unless defined by Android Subsystem