### PR TITLE
Fix write dispatcher

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 # Maven
 GROUP=com.mercury.sqkon
-VERSION_NAME=1.0.0-alpha12
+VERSION_NAME=1.0.0-alpha13
 POM_NAME=Sqkon
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/MercuryTechnologies/sqkon/

--- a/library/src/androidInstrumentedTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.android.kt
+++ b/library/src/androidInstrumentedTest/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriverTest.android.kt
@@ -1,10 +1,15 @@
 package com.mercury.sqkon.db
 
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
+@OptIn(ExperimentalUuidApi::class)
 internal actual fun driverFactory(): DriverFactory {
+    val uuid = Uuid.random()
     return DriverFactory(
         context = InstrumentationRegistry.getInstrumentation().targetContext,
-        name = null // in-memory database
+        // random file each time to make sure testing against file system and WAL is enabled
+        name = "sqkon-test-$uuid.db",
     )
 }

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
@@ -12,11 +12,20 @@ import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDriver
 import com.eygraber.sqldelight.androidx.driver.File
 import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import com.eygraber.sqldelight.androidx.driver.SqliteSync
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-internal val connectionPoolSize by lazy { getWALConnectionPoolSize() }
-internal val dbWriteDispatcher by lazy { Dispatchers.IO.limitedParallelism(1) }
-internal val dbReadDispatcher by lazy { Dispatchers.IO.limitedParallelism(connectionPoolSize) }
+internal actual val connectionPoolSize: Int by lazy { getWALConnectionPoolSize() }
+
+@PublishedApi
+internal actual val dbWriteDispatcher: CoroutineDispatcher by lazy {
+    Dispatchers.IO.limitedParallelism(1)
+}
+
+@PublishedApi
+internal actual val dbReadDispatcher: CoroutineDispatcher by lazy {
+    Dispatchers.IO.limitedParallelism(connectionPoolSize)
+}
 
 /**
  * @param name The name of the database to open or create. If null, an in-memory database will

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -232,7 +232,6 @@ class EntityQueries(
             AND entity_key IN (SELECT entity_key FROM entity${queries.buildFrom()} ${queries.buildWhere()})
             """.trimIndent()
         val sql = "DELETE FROM entity WHERE entity_name = ? $whereSubQuerySql"
-        println("SQL: $sql")
         try {
             driver.execute(
                 identifier = identifier,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -2,6 +2,8 @@ package com.mercury.sqkon.db
 
 import app.cash.paging.PagingSource
 import app.cash.sqldelight.SuspendingTransacter
+import app.cash.sqldelight.SuspendingTransactionWithReturn
+import app.cash.sqldelight.SuspendingTransactionWithoutReturn
 import app.cash.sqldelight.TransactionCallbacks
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
@@ -47,7 +49,7 @@ open class KeyValueStorage<T : Any>(
     protected val config: Config = Config(),
     protected val readDispatcher: CoroutineDispatcher,
     protected val writeDispatcher: CoroutineDispatcher,
-) : SuspendingTransacter by entityQueries {
+) : SuspendingTransacter {
 
     /**
      * Insert a row.
@@ -510,7 +512,7 @@ open class KeyValueStorage<T : Any>(
             when (config.deserializePolicy) {
                 DeserializePolicy.ERROR -> throw e
                 DeserializePolicy.DELETE -> {
-                    scope.launch { deleteByKey(entity_key) }
+                    scope.launch(writeDispatcher) { deleteByKey(entity_key) }
                     null
                 }
             }
@@ -546,8 +548,31 @@ open class KeyValueStorage<T : Any>(
      * dispatcher/writer.
      */
     private suspend fun <T> writeContext(block: suspend CoroutineScope.() -> T): T {
-        val dispatcher = coroutineContext[ContinuationInterceptor] ?: writeDispatcher
+        val dispatcher = (coroutineContext[ContinuationInterceptor] ?: writeDispatcher)
+        if (dispatcher != writeDispatcher) {
+            return withContext(writeDispatcher) { block() }
+        }
         return withContext(dispatcher) { block() }
+    }
+
+    // We force the transaction on to our writeContext to make sure we nest the enclosing
+    // transactions, otherwise we can create locks by transactions being started on different
+    // dispatchers.
+    override suspend fun transaction(
+        noEnclosing: Boolean,
+        body: suspend SuspendingTransactionWithoutReturn.() -> Unit
+    ) = writeContext {
+        entityQueries.transaction(noEnclosing, body)
+    }
+
+    // We force the transaction on to our writeContext to make sure we nest the enclosing
+    // transactions, otherwise we can create locks by transactions being started on different
+    // dispatchers.
+    override suspend fun <R> transactionWithResult(
+        noEnclosing: Boolean,
+        bodyWithReturn: suspend SuspendingTransactionWithReturn<R>.() -> R
+    ): R = writeContext {
+        entityQueries.transactionWithResult(noEnclosing, bodyWithReturn)
     }
 
     data class Config(
@@ -581,8 +606,8 @@ inline fun <reified T : Any> keyValueStorage(
     scope: CoroutineScope,
     serializer: SqkonSerializer = KotlinSqkonSerializer(),
     config: KeyValueStorage.Config = KeyValueStorage.Config(),
-    readDispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(4),
-    writeDispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1),
+    readDispatcher: CoroutineDispatcher = dbReadDispatcher,
+    writeDispatcher: CoroutineDispatcher = dbWriteDispatcher,
 ): KeyValueStorage<T> {
     return KeyValueStorage(
         entityName = entityName,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -30,6 +30,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.coroutineContext
+import kotlin.coroutines.suspendCoroutine
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -548,11 +549,7 @@ open class KeyValueStorage<T : Any>(
      * dispatcher/writer.
      */
     private suspend fun <T> writeContext(block: suspend CoroutineScope.() -> T): T {
-        val dispatcher = (coroutineContext[ContinuationInterceptor] ?: writeDispatcher)
-        if (dispatcher != writeDispatcher) {
-            return withContext(writeDispatcher) { block() }
-        }
-        return withContext(dispatcher) { block() }
+        return withContext(writeDispatcher) { block() }
     }
 
     // We force the transaction on to our writeContext to make sure we nest the enclosing

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.kt
@@ -1,6 +1,13 @@
 package com.mercury.sqkon.db
 
 import app.cash.sqldelight.db.SqlDriver
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal expect val connectionPoolSize: Int
+@PublishedApi
+internal expect val dbWriteDispatcher: CoroutineDispatcher
+@PublishedApi
+internal expect val dbReadDispatcher: CoroutineDispatcher
 
 internal expect class DriverFactory {
     fun createDriver(): SqlDriver

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
@@ -1,6 +1,7 @@
 package com.mercury.sqkon.db
 
 import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
@@ -18,7 +19,7 @@ class KeyValueStorageExpiresTest {
     private val entityQueries = EntityQueries(driver)
     private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(
-        "test-object", entityQueries, metadataQueries, mainScope
+        "test-object", entityQueries, metadataQueries, mainScope,
     )
 
     @After

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
@@ -42,7 +42,7 @@ class MetadataTest {
                 assertEquals("test-object", it.entity_name)
                 assertNotNull(it.lastWriteAt)
                 assertNull(it.lastReadAt)
-                assertTrue { it.lastWriteAt!! <= now }
+                assertTrue { it.lastWriteAt <= now }
             }
         }
     }
@@ -61,7 +61,7 @@ class MetadataTest {
                 assertEquals("test-object", it.entity_name)
                 assertNotNull(it.lastWriteAt)
                 assertNull(it.lastReadAt)
-                assertTrue { it.lastWriteAt!! > now }
+                assertTrue { it.lastWriteAt > now }
             }
         }
     }
@@ -80,8 +80,8 @@ class MetadataTest {
                 assertEquals("test-object", it.entity_name)
                 assertNotNull(it.lastWriteAt)
                 assertNotNull(it.lastReadAt)
-                assertTrue { it.lastWriteAt!! <= now }
-                assertTrue { it.lastReadAt!! > now }
+                assertTrue { it.lastWriteAt <= now }
+                assertTrue { it.lastReadAt > now }
             }
         }
     }

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
@@ -10,9 +10,15 @@ import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import com.eygraber.sqldelight.androidx.driver.SqliteSync
 import kotlinx.coroutines.Dispatchers
 
-internal const val connectionPoolSize = 4 // Default is 4 as per AndroidxSqliteConfiguration
-internal val dbWriteDispatcher by lazy { Dispatchers.IO.limitedParallelism(1) }
-internal val dbReadDispatcher by lazy { Dispatchers.IO.limitedParallelism(connectionPoolSize) }
+internal actual const val connectionPoolSize = 4 // Default is 4 as per AndroidxSqliteConfiguration
+
+@PublishedApi
+internal actual val dbWriteDispatcher by lazy { Dispatchers.IO.limitedParallelism(1) }
+
+@PublishedApi
+internal actual val dbReadDispatcher by lazy {
+    Dispatchers.IO.limitedParallelism(connectionPoolSize)
+}
 
 internal actual class DriverFactory(
     private val databaseType: AndroidxSqliteDatabaseType = AndroidxSqliteDatabaseType.Memory,


### PR DESCRIPTION
- Test WAL on Android by using a temp file not in memory
- Fix the use of the write dispatcher was only setting writeDispatcher if no dispatcher was defined (doy!)
- Override transaction to make sure when we call it we actually use the write dispatcher to make sure we get a single transaction for the call instead of potetial locking by the outer transaction being on a different dispatcher