### PR TITLE
Change Sqlite to Serialized Mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 # Maven
 GROUP=com.mercury.sqkon
-VERSION_NAME=1.0.0-alpha13
+VERSION_NAME=1.0.0-alpha14
 POM_NAME=Sqkon
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/MercuryTechnologies/sqkon/

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
@@ -4,6 +4,9 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Resources
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_CREATE
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_FULLMUTEX
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_READWRITE
 import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
@@ -35,9 +38,15 @@ internal actual class DriverFactory(
     private val context: Context,
     private val name: String? = "sqkon.db"
 ) {
+    private val driver = BundledSQLiteDriver()
     actual fun createDriver(): SqlDriver {
         return AndroidxSqliteDriver(
-            driver = BundledSQLiteDriver(),
+            createConnection = {
+                driver.open(
+                    fileName = it,
+                    flags = SQLITE_OPEN_READWRITE or SQLITE_OPEN_CREATE or SQLITE_OPEN_FULLMUTEX
+                )
+            },
             databaseType = when (name) {
                 null -> AndroidxSqliteDatabaseType.Memory
                 else -> AndroidxSqliteDatabaseType.File(context = context, name = name)

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
@@ -16,13 +16,16 @@ import com.eygraber.sqldelight.androidx.driver.File
 import com.eygraber.sqldelight.androidx.driver.SqliteJournalMode
 import com.eygraber.sqldelight.androidx.driver.SqliteSync
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.newFixedThreadPoolContext
 
 internal actual val connectionPoolSize: Int by lazy { getWALConnectionPoolSize() }
 
+@OptIn(DelicateCoroutinesApi::class)
 @PublishedApi
 internal actual val dbWriteDispatcher: CoroutineDispatcher by lazy {
-    Dispatchers.IO.limitedParallelism(1)
+    newFixedThreadPoolContext(nThreads = 1, "SqkonReadDispatcher")
 }
 
 @PublishedApi

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -62,22 +62,20 @@ open class KeyValueStorage<T : Any>(
         key: String, value: T,
         ignoreIfExists: Boolean = false,
         expiresAt: Instant? = null,
-    ) = writeContext {
-        transaction {
-            val now = nowMillis()
-            val entity = Entity(
-                entity_name = entityName,
-                entity_key = key,
-                added_at = now,
-                updated_at = now,
-                expires_at = expiresAt?.toEpochMilliseconds(),
-                read_at = null,
-                write_at = now,
-                value_ = serializer.serialize(type, value) ?: error("Failed to serialize value")
-            )
-            entityQueries.insertEntity(entity, ignoreIfExists)
-            updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: entity.hashCode())
-        }
+    ) = transaction {
+        val now = nowMillis()
+        val entity = Entity(
+            entity_name = entityName,
+            entity_key = key,
+            added_at = now,
+            updated_at = now,
+            expires_at = expiresAt?.toEpochMilliseconds(),
+            read_at = null,
+            write_at = now,
+            value_ = serializer.serialize(type, value) ?: error("Failed to serialize value")
+        )
+        entityQueries.insertEntity(entity, ignoreIfExists)
+        updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: entity.hashCode())
     }
 
     /**
@@ -94,11 +92,9 @@ open class KeyValueStorage<T : Any>(
         values: Map<String, T>,
         ignoreIfExists: Boolean = false,
         expiresAt: Instant? = null,
-    ) = writeContext {
+    ) = transaction {
         withContext(RequestHash(values.hashCode())) {
-            transaction {
-                values.forEach { (key, value) -> insert(key, value, ignoreIfExists, expiresAt) }
-            }
+            values.forEach { (key, value) -> insert(key, value, ignoreIfExists, expiresAt) }
         }
     }
 
@@ -113,16 +109,14 @@ open class KeyValueStorage<T : Any>(
      * @see insert
      * @see upsert
      */
-    suspend fun update(key: String, value: T, expiresAt: Instant? = null) = writeContext {
-        transaction {
-            entityQueries.updateEntity(
-                entityName = entityName,
-                entityKey = key,
-                expiresAt = expiresAt,
-                value = serializer.serialize(type, value) ?: error("Failed to serialize value")
-            )
-            updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: key.hashCode())
-        }
+    suspend fun update(key: String, value: T, expiresAt: Instant? = null) = transaction {
+        entityQueries.updateEntity(
+            entityName = entityName,
+            entityKey = key,
+            expiresAt = expiresAt,
+            value = serializer.serialize(type, value) ?: error("Failed to serialize value")
+        )
+        updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: key.hashCode())
     }
 
     /**
@@ -135,10 +129,10 @@ open class KeyValueStorage<T : Any>(
      * @see upsertAll
      */
     suspend fun updateAll(
-        values: Map<String, T>, expiresAt: Instant? = null
-    ) = writeContext {
+        values: Map<String, T>, expiresAt: Instant? = null,
+    ) = transaction {
         withContext(RequestHash(values.hashCode())) {
-            transaction { values.forEach { (key, value) -> update(key, value, expiresAt) } }
+            values.forEach { (key, value) -> update(key, value, expiresAt) }
         }
     }
 
@@ -152,13 +146,11 @@ open class KeyValueStorage<T : Any>(
      * @see update
      */
     suspend fun upsert(
-        key: String, value: T, expiresAt: Instant? = null
-    ) = writeContext {
+        key: String, value: T, expiresAt: Instant? = null,
+    ) = transaction {
         withContext(RequestHash(key.hashCode())) {
-            transaction {
-                update(key, value, expiresAt = expiresAt)
-                insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
-            }
+            update(key, value, expiresAt = expiresAt)
+            insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
         }
     }
 
@@ -174,14 +166,12 @@ open class KeyValueStorage<T : Any>(
      */
     suspend fun upsertAll(
         values: Map<String, T>,
-        expiresAt: Instant? = null
-    ) = writeContext {
+        expiresAt: Instant? = null,
+    ) = transaction {
         withContext(RequestHash(values.hashCode())) {
-            transaction {
-                values.forEach { (key, value) ->
-                    update(key, value, expiresAt = expiresAt)
-                    insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
-                }
+            values.forEach { (key, value) ->
+                update(key, value, expiresAt = expiresAt)
+                insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
             }
         }
     }
@@ -377,11 +367,9 @@ open class KeyValueStorage<T : Any>(
      * @see delete
      * @see deleteAll
      */
-    suspend fun deleteByKeys(vararg key: String) = writeContext {
-        transaction {
-            entityQueries.delete(entityName, entityKeys = key.toSet())
-            updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: key.hashCode())
-        }
+    suspend fun deleteByKeys(vararg key: String) = transaction {
+        entityQueries.delete(entityName, entityKeys = key.toSet())
+        updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: key.hashCode())
     }
 
     /**
@@ -393,11 +381,9 @@ open class KeyValueStorage<T : Any>(
      * @see deleteAll
      * @see deleteByKey
      */
-    suspend fun delete(where: Where<T>? = null) = writeContext {
-        transaction {
-            entityQueries.delete(entityName, where = where)
-            updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: where.hashCode())
-        }
+    suspend fun delete(where: Where<T>? = null) = transaction {
+        entityQueries.delete(entityName, where = where)
+        updateWriteAt(currentCoroutineContext()[RequestHash.Key]?.hash ?: where.hashCode())
     }
 
     /**
@@ -410,13 +396,11 @@ open class KeyValueStorage<T : Any>(
      *
      * @see deleteStale
      */
-    suspend fun deleteExpired(expiresAfter: Instant = Clock.System.now()) = writeContext {
-        transaction {
-            metadataQueries.purgeExpires(entityName, expiresAfter.toEpochMilliseconds())
-            updateWriteAt(
-                currentCoroutineContext()[RequestHash.Key]?.hash ?: expiresAfter.hashCode()
-            )
-        }
+    suspend fun deleteExpired(expiresAfter: Instant = Clock.System.now()) = transaction {
+        metadataQueries.purgeExpires(entityName, expiresAfter.toEpochMilliseconds())
+        updateWriteAt(
+            currentCoroutineContext()[RequestHash.Key]?.hash ?: expiresAfter.hashCode()
+        )
     }
 
     /**
@@ -434,39 +418,37 @@ open class KeyValueStorage<T : Any>(
      */
     suspend fun deleteStale(
         writeInstant: Instant? = Clock.System.now(),
-        readInstant: Instant? = Clock.System.now()
-    ) = writeContext {
-        transaction {
-            when {
-                writeInstant != null && readInstant != null -> {
-                    metadataQueries.purgeStale(
-                        entity_name = entityName,
-                        writeInstant = writeInstant.toEpochMilliseconds(),
-                        readInstant = readInstant.toEpochMilliseconds()
-                    )
-                }
-
-                writeInstant != null -> {
-                    metadataQueries.purgeStaleWrite(
-                        entity_name = entityName,
-                        writeInstant = writeInstant.toEpochMilliseconds()
-                    )
-                }
-
-                readInstant != null -> {
-                    metadataQueries.purgeStaleRead(
-                        entity_name = entityName,
-                        readInstant = readInstant.toEpochMilliseconds()
-                    )
-                }
-
-                else -> return@transaction
+        readInstant: Instant? = Clock.System.now(),
+    ) = transaction {
+        when {
+            writeInstant != null && readInstant != null -> {
+                metadataQueries.purgeStale(
+                    entity_name = entityName,
+                    writeInstant = writeInstant.toEpochMilliseconds(),
+                    readInstant = readInstant.toEpochMilliseconds()
+                )
             }
-            updateWriteAt(
-                currentCoroutineContext()[RequestHash.Key]?.hash
-                    ?: (writeInstant.hashCode() + readInstant.hashCode())
-            )
+
+            writeInstant != null -> {
+                metadataQueries.purgeStaleWrite(
+                    entity_name = entityName,
+                    writeInstant = writeInstant.toEpochMilliseconds()
+                )
+            }
+
+            readInstant != null -> {
+                metadataQueries.purgeStaleRead(
+                    entity_name = entityName,
+                    readInstant = readInstant.toEpochMilliseconds()
+                )
+            }
+
+            else -> return@transaction
         }
+        updateWriteAt(
+            currentCoroutineContext()[RequestHash.Key]?.hash
+                ?: (writeInstant.hashCode() + readInstant.hashCode())
+        )
     }
 
     /**
@@ -485,7 +467,7 @@ open class KeyValueStorage<T : Any>(
 
     fun count(
         where: Where<T>? = null,
-        expiresAfter: Instant? = null
+        expiresAfter: Instant? = null,
     ): Flow<Int> {
         return entityQueries.count(entityName, where, expiresAfter)
             .asFlow()
@@ -554,7 +536,7 @@ open class KeyValueStorage<T : Any>(
     // dispatchers.
     override suspend fun transaction(
         noEnclosing: Boolean,
-        body: suspend SuspendingTransactionWithoutReturn.() -> Unit
+        body: suspend SuspendingTransactionWithoutReturn.() -> Unit,
     ) = writeContext {
         entityQueries.transaction(noEnclosing, body)
     }
@@ -564,7 +546,7 @@ open class KeyValueStorage<T : Any>(
     // dispatchers.
     override suspend fun <R> transactionWithResult(
         noEnclosing: Boolean,
-        bodyWithReturn: suspend SuspendingTransactionWithReturn<R>.() -> R
+        bodyWithReturn: suspend SuspendingTransactionWithReturn<R>.() -> R,
     ): R = writeContext {
         entityQueries.transactionWithResult(noEnclosing, bodyWithReturn)
     }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -531,6 +531,12 @@ open class KeyValueStorage<T : Any>(
         return withContext(writeDispatcher) { block() }
     }
 
+
+    // TODO exposed transaction should get a lock on the current context to see if it needs
+    //   to wait to acquire a lock instead of being on the same thread, this will make sure only one
+    //   transaction is running at a time. (as right now ThreadLocal means we can muddle ops by
+    //   calling suspending functions back to back)
+
     // We force the transaction on to our writeContext to make sure we nest the enclosing
     // transactions, otherwise we can create locks by transactions being started on different
     // dispatchers.

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -28,9 +28,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.coroutineContext
-import kotlin.coroutines.suspendCoroutine
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -550,26 +547,6 @@ open class KeyValueStorage<T : Any>(
      */
     private suspend fun <T> writeContext(block: suspend CoroutineScope.() -> T): T {
         return withContext(writeDispatcher) { block() }
-    }
-
-    // We force the transaction on to our writeContext to make sure we nest the enclosing
-    // transactions, otherwise we can create locks by transactions being started on different
-    // dispatchers.
-    override suspend fun transaction(
-        noEnclosing: Boolean,
-        body: suspend SuspendingTransactionWithoutReturn.() -> Unit
-    ) = writeContext {
-        entityQueries.transaction(noEnclosing, body)
-    }
-
-    // We force the transaction on to our writeContext to make sure we nest the enclosing
-    // transactions, otherwise we can create locks by transactions being started on different
-    // dispatchers.
-    override suspend fun <R> transactionWithResult(
-        noEnclosing: Boolean,
-        bodyWithReturn: suspend SuspendingTransactionWithReturn<R>.() -> R
-    ): R = writeContext {
-        entityQueries.transactionWithResult(noEnclosing, bodyWithReturn)
     }
 
     // We force the transaction on to our writeContext to make sure we nest the enclosing

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -572,6 +572,26 @@ open class KeyValueStorage<T : Any>(
         entityQueries.transactionWithResult(noEnclosing, bodyWithReturn)
     }
 
+    // We force the transaction on to our writeContext to make sure we nest the enclosing
+    // transactions, otherwise we can create locks by transactions being started on different
+    // dispatchers.
+    override suspend fun transaction(
+        noEnclosing: Boolean,
+        body: suspend SuspendingTransactionWithoutReturn.() -> Unit
+    ) = writeContext {
+        entityQueries.transaction(noEnclosing, body)
+    }
+
+    // We force the transaction on to our writeContext to make sure we nest the enclosing
+    // transactions, otherwise we can create locks by transactions being started on different
+    // dispatchers.
+    override suspend fun <R> transactionWithResult(
+        noEnclosing: Boolean,
+        bodyWithReturn: suspend SuspendingTransactionWithReturn<R>.() -> R
+    ): R = writeContext {
+        entityQueries.transactionWithResult(noEnclosing, bodyWithReturn)
+    }
+
     data class Config(
         val deserializePolicy: DeserializePolicy = DeserializePolicy.ERROR,
         @Deprecated("Use we use predefined dispatchers for read/write. This is unused now.")


### PR DESCRIPTION
We were seeing native crashes despite using limitedParallization dispatchers, seems Sqlite still gets upset if not the exact same thread, this puts back into serialized mode (which is default from the sqlite team).

Refs:
- https://issuetracker.google.com/issues/340949940
- https://github.com/teambtcmap/btcmap-android/blob/master/app/src/main/kotlin/db/Database.kt#L24-L54