### PR TITLE
Make transactions sync

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidx-monitor = "1.7.2"
 androidx-runner = "1.6.2"
-androidx-sqlite = "2.5.0"
+androidx-sqlite = "2.5.1"
 kotlin = "2.1.20"
 agp = "8.9.2"
 kotlinx-coroutines = "1.10.2"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -92,7 +92,9 @@ sqldelight {
         create("SqkonDatabase") {
             // Database configuration here.
             // https://cashapp.github.io/sqldelight
-            generateAsync = true
+            // We disable async as it's effectively broken on multithreaded platforms with
+            // coroutines (more of a driver issue)
+            generateAsync = false
             packageName.set("com.mercury.sqkon.db")
             schemaOutputDirectory.set(file("src/commonMain/sqldelight/databases"))
             // We're technically using 3.45.0, but 3.38 is the latest supported version

--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.android.kt
@@ -7,7 +7,6 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.driver.bundled.SQLITE_OPEN_CREATE
 import androidx.sqlite.driver.bundled.SQLITE_OPEN_FULLMUTEX
 import androidx.sqlite.driver.bundled.SQLITE_OPEN_READWRITE
-import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
@@ -54,7 +53,7 @@ internal actual class DriverFactory(
                 null -> AndroidxSqliteDatabaseType.Memory
                 else -> AndroidxSqliteDatabaseType.File(context = context, name = name)
             },
-            schema = SqkonDatabase.Schema.synchronous(),
+            schema = SqkonDatabase.Schema,
             configuration = AndroidxSqliteConfiguration(
                 journalMode = SqliteJournalMode.WAL,
                 sync = SqliteSync.Normal,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -510,7 +510,11 @@ open class KeyValueStorage<T : Any>(
         updateWriteHashes.add(requestHash)
         afterCommit {
             updateWriteHashes.remove(requestHash)
-            metadataQueries.upsertWrite(entityName, Clock.System.now())
+            scope.launch(writeDispatcher) {
+                metadataQueries.transaction {
+                    metadataQueries.upsertWrite(entityName, Clock.System.now())
+                }
+            }
         }
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
@@ -2,6 +2,7 @@ package com.mercury.sqkon.db
 
 import com.mercury.sqkon.db.serialization.KotlinSqkonSerializer
 import com.mercury.sqkon.db.serialization.SqkonJson
+import com.mercury.sqkon.db.utils.SqkonTransacter
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +38,12 @@ class Sqkon internal constructor(
         Dispatchers.Default.limitedParallelism(1),
 ) {
 
+    /**
+     * Sqkon internal transactor.
+     */
+    @PublishedApi
+    internal val transactor = SqkonTransacter(driver = entityQueries.sqlDriver)
+
     @PublishedApi
     internal val serializer = KotlinSqkonSerializer(json)
 
@@ -57,6 +64,7 @@ class Sqkon internal constructor(
             name, entityQueries, metadataQueries, scope, serializer, config,
             readDispatcher = readDispatcher,
             writeDispatcher = writeDispatcher,
+            transactor = transactor,
         )
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -9,7 +9,7 @@ import app.cash.paging.PagingSourceLoadResultInvalid
 import app.cash.paging.PagingSourceLoadResultPage
 import app.cash.paging.PagingState
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.SuspendingTransacter
+import app.cash.sqldelight.Transacter
 import app.cash.sqldelight.TransactionCallbacks
 import com.mercury.sqkon.db.Entity
 import kotlinx.coroutines.withContext
@@ -18,7 +18,7 @@ import kotlin.coroutines.CoroutineContext
 internal class OffsetQueryPagingSource<T : Any>(
     private val queryProvider: (limit: Int, offset: Int) -> Query<Entity>,
     private val countQuery: Query<Int>,
-    private val transacter: SuspendingTransacter,
+    private val transacter: Transacter,
     private val context: CoroutineContext,
     private val deserialize: (Entity) -> T?,
     private val initialOffset: Int,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/SqkonTransacter.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/SqkonTransacter.kt
@@ -1,0 +1,61 @@
+package com.mercury.sqkon.db.utils
+
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.TransactionWithReturn
+import app.cash.sqldelight.TransactionWithoutReturn
+import app.cash.sqldelight.db.SqlDriver
+
+open class SqkonTransacter(driver: SqlDriver) : TransacterImpl(driver) {
+
+    // Child -> Parent
+    protected val trxMap = mutableMapOf<Transacter.Transaction, Transacter.Transaction?>()
+
+    fun Transacter.Transaction.parentTransactionHash(): Int {
+        // Get enclosing transaction, otherwise we're probably top level, use that hashcode
+        return trxMap[this]?.parentTransactionHash() ?: this.hashCode()
+    }
+
+    override fun transaction(
+        noEnclosing: Boolean,
+        body: TransactionWithoutReturn.() -> Unit
+    ) {
+        val parentTrx = driver.currentTransaction()
+        return super.transaction(
+            noEnclosing = noEnclosing,
+            body = {
+                // Inside transaction here
+                val currentTrx = driver.currentTransaction()!!
+                trxMap[currentTrx] = parentTrx
+                try {
+                    body()
+                } finally {
+                    // End of transaction
+                    trxMap.remove(currentTrx)
+                }
+            }
+        )
+    }
+
+    override fun <R> transactionWithResult(
+        noEnclosing: Boolean,
+        bodyWithReturn: TransactionWithReturn<R>.() -> R
+    ): R {
+        val parentTrx = driver.currentTransaction()
+        return super.transactionWithResult(
+            noEnclosing = noEnclosing,
+            bodyWithReturn = {
+                // Inside transaction here
+                val currentTrx = driver.currentTransaction()!!
+                trxMap[currentTrx] = parentTrx
+                try {
+                    bodyWithReturn()
+                } finally {
+                    // End of transaction
+                    trxMap.remove(currentTrx)
+                }
+            }
+        )
+    }
+
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/MetadataTest.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.Clock
 import org.junit.After
 import org.junit.Test
 import java.lang.Thread.sleep
+import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -42,7 +43,7 @@ class MetadataTest {
                 assertEquals("test-object", it.entity_name)
                 assertNotNull(it.lastWriteAt)
                 assertNull(it.lastReadAt)
-                assertTrue { it.lastWriteAt <= now }
+                assertTrue("lastWriteAt not <= now") { it.lastWriteAt <= now }
             }
         }
     }

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.jvm.kt
@@ -1,7 +1,6 @@
 package com.mercury.sqkon.db
 
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
-import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
@@ -28,7 +27,7 @@ internal actual class DriverFactory(
         return AndroidxSqliteDriver(
             driver = BundledSQLiteDriver(),
             databaseType = databaseType,
-            schema = SqkonDatabase.Schema.synchronous(),
+            schema = SqkonDatabase.Schema,
             configuration = AndroidxSqliteConfiguration(
                 journalMode = SqliteJournalMode.WAL,
                 sync = SqliteSync.Normal,


### PR DESCRIPTION
There is an underlying issue when writes are async as transactions become unsafe due to dispatching multiple request inside the same request can cause multiple transactions to be muddled, or worst case, a request which thinks it's inside a transaction can be closed as transaction can be shared without knowledge to the user causing a database lock and crash.

- This forces transactions and writes to be synchronous 
- Transactions are still looked up using the current thread, so don't try and thread inside of a transaction 