### PR TITLE
Serializable value binding

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 /**
- * Create a Path builder using one of the manu reified methods.
+ * Create a Path builder using one of the many reified methods.
  *
  * From a class:
  *
@@ -27,6 +27,7 @@ import kotlin.reflect.typeOf
  * val builder = TestObject::statuses.builder {
  *   then(Status::createdAt)
  * }
+ * ```
  *
  * Quick joining two properties:
  *
@@ -117,20 +118,24 @@ class JsonPathBuilder<R : Any>
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    fun fieldNames(): List<String> {
+    fun fieldNames(element: Boolean = false): List<String> {
         return nodes().mapNotNull { it ->
             if (it.receiverDescriptor.isInline) return@mapNotNull null // Skip inline classes
             val prefix = if (it.propertyName.isNotBlank()) "." else ""
-            when (it.valueDescriptor.kind) {
-                StructureKind.LIST -> "$prefix${it.propertyName}[%]"
-                PolymorphicKind.SEALED -> "$prefix${it.propertyName}[1]"
-                else -> "$prefix${it.propertyName}"
+            if (element) {
+                when (it.valueDescriptor.kind) {
+                    StructureKind.LIST -> "$prefix${it.propertyName}[%]"
+                    PolymorphicKind.SEALED -> "$prefix${it.propertyName}[1]"
+                    else -> "$prefix${it.propertyName}"
+                }
+            } else {
+                "$prefix${it.propertyName}"
             }
         }
     }
 
     fun buildPath(): String {
-        return fieldNames().joinToString("", prefix = "\$")
+        return fieldNames().joinToString("", prefix = "$")
     }
 }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -201,6 +201,7 @@ open class KeyValueStorage<T : Any>(
                 entityKeys = keys,
                 orderBy = orderBy,
                 expiresAt = expiresAfter,
+                serializer = serializer,
             )
             .asFlow()
             .mapToList(readDispatcher)
@@ -239,6 +240,7 @@ open class KeyValueStorage<T : Any>(
                 limit = limit,
                 offset = offset,
                 expiresAt = expiresAfter,
+                serializer = serializer,
             )
             .asFlow()
             .mapToList(readDispatcher)
@@ -278,6 +280,7 @@ open class KeyValueStorage<T : Any>(
                 limit = limit,
                 offset = offset,
                 expiresAt = expiresAfter,
+                serializer = serializer,
             )
             .asFlow()
             .mapToList(readDispatcher)
@@ -317,6 +320,7 @@ open class KeyValueStorage<T : Any>(
                 limit = limit.toLong(),
                 offset = offset.toLong(),
                 expiresAt = expiresAfter,
+                serializer = serializer,
             ).also { entities ->
                 updateReadAt(entities.executeAsList().map { it.entity_key })
             }
@@ -454,7 +458,7 @@ open class KeyValueStorage<T : Any>(
         where: Where<T>? = null,
         expiresAfter: Instant? = null,
     ): Flow<Int> {
-        return entityQueries.count(entityName, where, expiresAfter)
+        return entityQueries.count(entityName, where, expiresAfter, serializer)
             .asFlow()
             .mapToOne(readDispatcher)
     }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -93,6 +93,7 @@ data class TypeTwoData(
     val otherValue: Int
 )
 
+@Serializable
 enum class TestEnum {
     FIRST,
     SECOND,

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEnumTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEnumTest.kt
@@ -2,6 +2,7 @@
 
 package com.mercury.sqkon.db
 
+import app.cash.sqldelight.logs.LogSqliteDriver
 import com.mercury.sqkon.TestEnum
 import com.mercury.sqkon.TestObject
 import kotlinx.coroutines.MainScope
@@ -16,7 +17,9 @@ import kotlin.uuid.ExperimentalUuidApi
 class KeyValueStorageEnumTest {
 
     private val mainScope = MainScope()
-    private val driver = driverFactory().createDriver()
+    private val driver = LogSqliteDriver(driverFactory().createDriver()) {
+        println(it)
+    }
     private val entityQueries = EntityQueries(driver)
     private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(
@@ -55,9 +58,8 @@ class KeyValueStorageEnumTest {
         val bySecondEnum = testObjectStorage.select(
             where = TestObject::testEnum eq TestEnum.SECOND,
         ).first()
-        // Broken due to lack of serialName support from descriptors
         val byLastEnum = testObjectStorage.select(
-            where = TestObject::testEnum eq "unknown",
+            where = TestObject::testEnum eq TestEnum.LAST,
         ).first()
 
         assertEquals(0, bySecondEnum.size)

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiresTest.kt
@@ -1,5 +1,6 @@
 package com.mercury.sqkon.db
 
+import app.cash.sqldelight.logs.LogSqliteDriver
 import com.mercury.sqkon.TestObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -15,7 +16,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class KeyValueStorageExpiresTest {
 
     private val mainScope = MainScope()
-    private val driver = driverFactory().createDriver()
+    private val driver = LogSqliteDriver(driverFactory().createDriver(), ::println)
     private val entityQueries = EntityQueries(driver)
     private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageSealedTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageSealedTest.kt
@@ -2,6 +2,7 @@
 
 package com.mercury.sqkon.db
 
+import app.cash.sqldelight.logs.LogSqliteDriver
 import com.mercury.sqkon.BaseSealed
 import com.mercury.sqkon.TestObject
 import com.mercury.sqkon.TestSealed
@@ -20,7 +21,9 @@ import kotlin.uuid.Uuid
 class KeyValueStorageSealedTest {
 
     private val mainScope = MainScope()
-    private val driver = driverFactory().createDriver()
+    private val driver = LogSqliteDriver(driverFactory().createDriver()) {
+        println(it)
+    }
     private val entityQueries = EntityQueries(driver)
     private val metadataQueries = MetadataQueries(driver)
     private val testObjectStorage = keyValueStorage<TestObject>(

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/serialization/KotlinSqkonSerializerKtTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/serialization/KotlinSqkonSerializerKtTest.kt
@@ -1,9 +1,13 @@
 package com.mercury.sqkon.serialization
 
+import com.mercury.sqkon.TestEnum
 import com.mercury.sqkon.TestObject
 import com.mercury.sqkon.TestSealed
+import com.mercury.sqkon.db.serialization.KotlinSqkonSerializer
 import com.mercury.sqkon.db.serialization.SqkonJson
+import kotlin.reflect.typeOf
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class KotlinSqkonSerializerKtTest {
@@ -22,4 +26,10 @@ class KotlinSqkonSerializerKtTest {
 
     }
 
+    @Test
+    fun testEnumSerialNameSerialization() {
+        val serializer = KotlinSqkonSerializer()
+        val value = TestEnum.LAST
+        assertEquals("\"unknown\"", serializer.serialize(typeOf<TestEnum>(), value))
+    }
 }


### PR DESCRIPTION
This is an experiment to allow building queries using Kotlin types instead of their equivalent representation in SQL. For example:

```kotlin
 # Current: Need to pass in the enum name in SQL
TestObject::testEnum eq "first"

# New: Can pass in the enum value, will be serialized to JSON
TestObject::testEnum eq TestEnum.FIRST
```

`AutoIncrementSqlPreparedStatement.bindValue` now serializes value arguments to JSON. Several queries now use `json_quote` to normalize values passed via prepared statement bindings.