### PR TITLE
fix: pin release-please-action to correct SHA for v4.4.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f2a2b96b20c # v4.2.2
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The squash merge of #34 flattened all commits, so the SHA fix never landed on main. The workflow still references the bogus `a02a34c...` hash, which is why the release-please run failed.

Pins to `5c625bf...` — the actual `v4.4.1` release tag.

## Test plan

- [ ] Release-please workflow should pass on the next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)