### PR TITLE
fix: enable pretty permalinks so child docs pages resolve

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,11 @@ url: https://mercurytechnologies.github.io
 baseurl: /sqkon
 theme: just-the-docs
 
+# Generate /section/page/index.html instead of /section/page.html so internal
+# `{{ '/path/' | relative_url }}` links (and the nav, which uses trailing
+# slashes too) resolve on GitHub Pages without manual rewrites.
+permalink: pretty
+
 # --- Theme ---
 color_scheme: mercury
 logo: /assets/images/logo.svg


### PR DESCRIPTION
## Summary

Follow-up to #42. After that merged, the `deploy-docs` workflow ran successfully and the site went live — but every child page (`/getting-started/quickstart/`, `/guides/querying/`, etc.) returned **404**. Only `/` and `/api/` worked.

## Root cause

Jekyll's default permalink generates `/section/page.html`, but every internal link in the site uses trailing slashes — both my own `{{ '/path/' | relative_url }}` references and Just the Docs' navigation. GitHub Pages doesn't auto-rewrite trailing slashes to `.html`, so the URLs we link to literally don't exist on disk.

html-proofer passed locally because it resolves links against the filesystem and accepts either form; only live serving exposed the gap.

## Fix

Add `permalink: pretty` to `docs/_config.yml`. Jekyll now writes `/section/page/index.html` for every child page, which matches the trailing-slash URLs the site links.

## Verification (local)

```
✓ _site/getting-started/quickstart/index.html
✓ _site/guides/querying/index.html
✓ _site/guides/paging/index.html
✓ _site/concepts/architecture/index.html
✓ _site/reference/changelog/index.html
✓ _site/examples/feature-flags/index.html
```

The landing page (`/`) and Dokka output (`/api/`) keep working — both are already filesystem-backed at trailing-slash paths.

## Test plan

- [ ] CI passes
- [ ] After merge, `deploy-docs` workflow runs and deploys
- [ ] `curl -o /dev/null -w "%{http_code}\n" https://mercurytechnologies.github.io/sqkon/getting-started/quickstart/` returns 200 (was 404)
- [ ] Spot-check several other child pages return 200
- [ ] Site navigation in the browser works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)