### PR TITLE
feat!: CASE/WHEN value-selection + predicate-dispatch (MOB-1627)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -133,6 +133,34 @@ storage.select(orderBy = listOf(OrderBy(effectiveTime, OrderDirection.DESC)))
 
 Supported comparison operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `lt`, plus `isNull()` / `isNotNull()` (rows whose variant has no matching `whenIs` branch fall through to NULL). `case { … }` is also available on a sealed *property* (e.g. `MyEntity::status.case<MyEntity, Status> { … }`) for the common case where the sealed type is nested inside a larger object.
 
+### Per-variant *predicates* — `caseWhere`
+
+The `case { ... }` form above picks a value path; if you instead need a
+*different predicate per variant* (different fields, operators, RHS types),
+use `caseWhere { ... }`. The result is a `Where<T>` you can drop straight
+into `select(where = ...)`:
+
+```kotlin
+orders.select(where = Order::class.caseWhere {
+    whenIs<Order.Active>    { with(Order.Active::dueAt) lt cutoff }
+    whenIs<Order.Pending>   { with(Order.Pending::reviewedAt) eq null }
+    whenIs<Order.Cancelled> { with(Order.Cancelled::reason) eq "BLOCKED" }
+})
+```
+
+For non-sealed types with a discriminator field, dispatch on the property:
+
+```kotlin
+shipments.select(where = caseWhere(Shipment::status) {
+    whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }
+    whenEq(ShipmentStatus.RETURNED) { Shipment::returnedAt gt cutoff }
+    default { Shipment::flagged eq true }
+})
+```
+
+`caseWhere` is WHERE-only. Use the value-selection `case` if you need a
+single value to feed into `ORDER BY`.
+
 ## Paging
 
 Sqkon provides two `PagingSource` factories on `KeyValueStorage` that plug into AndroidX Paging 3:

--- a/README.MD
+++ b/README.MD
@@ -131,7 +131,7 @@ storage.select(where = effectiveTime gt 1_700_000_000L)
 storage.select(orderBy = listOf(OrderBy(effectiveTime, OrderDirection.DESC)))
 ```
 
-Supported comparison operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, plus `isNull()` / `isNotNull()` (rows whose variant has no matching `whenIs` branch fall through to NULL). `case { … }` is also available on a sealed *property* (e.g. `MyEntity::status.case<MyEntity, Status> { … }`) for the common case where the sealed type is nested inside a larger object.
+Supported comparison operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `lt`, plus `isNull()` / `isNotNull()` (rows whose variant has no matching `whenIs` branch fall through to NULL). `case { … }` is also available on a sealed *property* (e.g. `MyEntity::status.case<MyEntity, Status> { … }`) for the common case where the sealed type is nested inside a larger object.
 
 ## Paging
 

--- a/README.MD
+++ b/README.MD
@@ -103,6 +103,36 @@ val cardNumberWhere = Card::cardNumber eq "1234"
 
 ```
 
+### CASE / WHEN: choosing a path per variant
+
+The `with`-style queries above match a single field across variants. When you need to **filter or order by a value that lives under a different field name in each variant**, use a `CaseWhen<T>` expression. It compiles to a SQL `CASE WHEN … END` over the sealed discriminator.
+
+```kotlin
+@Serializable
+sealed interface Status {
+    val id: String
+    @Serializable @SerialName("Active")
+    data class Active(override val id: String, val activatedAt: Long) : Status
+    @Serializable @SerialName("Pending")
+    data class Pending(override val id: String, val requestedAt: Long) : Status
+}
+
+// Build a value expression: "the timestamp that means 'when this happened',
+// regardless of which variant the row holds".
+val effectiveTime: CaseWhen<Status> = Status::class.case {
+    whenIs<Status.Active>(Status::class.with(Status.Active::activatedAt))
+    whenIs<Status.Pending>(Status::class.with(Status.Pending::requestedAt))
+}
+
+// Filter: rows whose effective timestamp is after a pivot, across both variants.
+storage.select(where = effectiveTime gt 1_700_000_000L)
+
+// Order: sort the mixed result set by the per-variant timestamp.
+storage.select(orderBy = listOf(OrderBy(effectiveTime, OrderDirection.DESC)))
+```
+
+Supported comparison operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, plus `isNull()` / `isNotNull()` (rows whose variant has no matching `whenIs` branch fall through to NULL). `case { … }` is also available on a sealed *property* (e.g. `MyEntity::status.case<MyEntity, Status> { … }`) for the common case where the sealed type is nested inside a larger object.
+
 ## Paging
 
 Sqkon provides two `PagingSource` factories on `KeyValueStorage` that plug into AndroidX Paging 3:

--- a/docs/guides/ordering.md
+++ b/docs/guides/ordering.md
@@ -121,6 +121,30 @@ merchants.selectAll(
 ).first()
 ```
 
+## Ordering by a per-variant value (CASE)
+
+When the store holds a sealed type whose variants don't share a common
+field name — say "the timestamp this row last changed" lives at
+`activatedAt` for `Active` and `requestedAt` for `Pending` — pass a
+`CaseWhen<T>` to `OrderBy` and the store will sort by the right field
+per row:
+
+```kotlin
+val effectiveTime: CaseWhen<Status> = Status::class.case {
+    whenIs<Status.Active>(Status::class.with(Status.Active::activatedAt))
+    whenIs<Status.Pending>(Status::class.with(Status.Pending::requestedAt))
+}
+
+statusStore.select(
+    orderBy = listOf(OrderBy(effectiveTime, OrderDirection.DESC)),
+).first()
+```
+
+Rows whose variant has no matching `whenIs` branch fall through to NULL
+and sort to the end (SQLite default for NULLs). See
+[Querying → CASE / WHEN]({{ '/guides/querying/#case--when-per-variant-path-selection' | relative_url }})
+for the full builder syntax.
+
 ## Where to next
 
 - [Querying]({{ '/guides/querying/' | relative_url }}) — combine ordering with filters.

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -53,6 +53,7 @@ jump to its section.
 | [`gt`](#numeric-comparison-gt-lt) / [`lt`](#numeric-comparison-gt-lt) | strict greater/less |
 | [`inList`](#set-membership-inlist-notinlist) / [`notInList`](#set-membership-inlist-notinlist) | value present in / absent from a list |
 | [`and`](#boolean-composition-and-or-not) / [`or`](#boolean-composition-and-or-not) / [`not`](#boolean-composition-and-or-not) | combine other Wheres |
+| [`case { … }`](#case--when-per-variant-path-selection) | pick a JSON path per sealed-class variant (CASE/WHEN) |
 
 All operators are available as **infix functions on a `KProperty1`** (the
 common case — `Merchant::name`) or on a `JsonPathBuilder` for nested fields
@@ -240,6 +241,54 @@ val byId = merchants.select(
 ```
 
 Reference test: `select_byEntityId`.
+
+## CASE / WHEN: per-variant path selection
+
+Standard operators like `eq` and `gt` match a **single JSON path** against
+every row. When the store holds a sealed type and you want a value whose
+path differs per variant — for example "the timestamp of whatever happened
+to this row" — use a `CaseWhen<T>` expression.
+
+```kotlin
+@Serializable
+sealed interface Status {
+    @Serializable @SerialName("Active")
+    data class Active(val activatedAt: Long) : Status
+    @Serializable @SerialName("Pending")
+    data class Pending(val requestedAt: Long) : Status
+}
+
+val effectiveTime: CaseWhen<Status> = Status::class.case {
+    whenIs<Status.Active>(Status::class.with(Status.Active::activatedAt))
+    whenIs<Status.Pending>(Status::class.with(Status.Pending::requestedAt))
+}
+
+val recent = statusStore.select(where = effectiveTime gt 1_700_000_000L).first()
+```
+
+`CaseWhen<T>` compiles to a SQL `CASE WHEN … END` over the sealed
+discriminator. Each `whenIs<V>` picks the value path used when the row's
+discriminator matches `V`'s `@SerialName`. Rows whose variant has no
+matching branch fall through to SQL `NULL` — `<op> NULL` is falsy in a
+WHERE, so they're filtered out automatically.
+
+`case { … }` is also available on a sealed *property* when the sealed type
+is nested inside a larger object:
+
+```kotlin
+val time = Account::status.case<Account, Status> {
+    whenIs<Status.Active>(Account::status.then(Status.Active::activatedAt))
+    whenIs<Status.Pending>(Account::status.then(Status.Pending::requestedAt))
+}
+```
+
+Operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `lt`, plus `isNull()` /
+`isNotNull()` (handy for selecting rows that fell through every branch).
+A `CaseWhen` predicate composes with the json-tree-based operators above
+under `and` / `or` exactly like any other `Where<T>`.
+
+For ordering by a `CaseWhen` value, see
+[Ordering]({{ '/guides/ordering/' | relative_url }}).
 
 ## Common pitfalls
 

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -54,6 +54,7 @@ jump to its section.
 | [`inList`](#set-membership-inlist-notinlist) / [`notInList`](#set-membership-inlist-notinlist) | value present in / absent from a list |
 | [`and`](#boolean-composition-and-or-not) / [`or`](#boolean-composition-and-or-not) / [`not`](#boolean-composition-and-or-not) | combine other Wheres |
 | [`case { … }`](#case--when-per-variant-path-selection) | pick a JSON path per sealed-class variant (CASE/WHEN) |
+| [`caseWhere { … }`](#case--when-per-variant-predicate-selection) | pick a JSON predicate per sealed-class variant or per discriminator field |
 
 All operators are available as **infix functions on a `KProperty1`** (the
 common case — `Merchant::name`) or on a `JsonPathBuilder` for nested fields
@@ -289,6 +290,95 @@ under `and` / `or` exactly like any other `Where<T>`.
 
 For ordering by a `CaseWhen` value, see
 [Ordering]({{ '/guides/ordering/' | relative_url }}).
+
+## CASE / WHEN: per-variant predicate selection
+
+The `case { … }` expression above selects a *value path* per variant — one
+operator (`eq`, `gt`, …) compared against one RHS. When you instead want a
+*different predicate per variant* — different fields, different operators,
+different RHS types — use `caseWhere { … }`. It compiles to a SQL
+`CASE WHEN <disc> = ? THEN <pred> ... [ELSE <pred>] END` placed inside `WHERE`.
+
+```kotlin
+@Serializable
+sealed interface Order {
+    val id: String
+    @Serializable @SerialName("Active")
+    data class Active(override val id: String, val dueAt: Long, val priority: Int) : Order
+    @Serializable @SerialName("Pending")
+    data class Pending(override val id: String, val reviewedAt: Long?) : Order
+    @Serializable @SerialName("Cancelled")
+    data class Cancelled(override val id: String, val reason: String) : Order
+}
+
+orders.select(
+    where = Order::class.caseWhere {
+        whenIs<Order.Active>    { with(Order.Active::dueAt) lt cutoff }
+        whenIs<Order.Pending>   { with(Order.Pending::reviewedAt) eq null }
+        whenIs<Order.Cancelled> { with(Order.Cancelled::reason) eq "BLOCKED" }
+    },
+).first()
+```
+
+Inside each branch, `with(KProperty1<V, X>)` is **scoped to the variant** —
+`with(Pending::reviewedAt)` won't compile inside a `whenIs<Active> { ... }`
+block.
+
+### Compound predicates per branch
+
+Each branch is a full `Where<T>` — `and`/`or`/`not` compose normally:
+
+```kotlin
+Order::class.caseWhere {
+    whenIs<Order.Active> {
+        (with(Order.Active::priority) gt 5)
+            .and(with(Order.Active::dueAt) lt cutoff)
+    }
+}
+```
+
+### Discriminator-field dispatch (non-sealed)
+
+When the discriminator is a regular field (enum, string), pass the property
+to `caseWhere` instead of starting from `KClass`:
+
+```kotlin
+shipments.select(
+    where = caseWhere(Shipment::status) {
+        whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }
+        whenEq(ShipmentStatus.RETURNED) { Shipment::returnedAt gt cutoff }
+        default { Shipment::flagged eq true }
+    },
+).first()
+```
+
+`whenEq(value)` requires the value type to match the discriminator
+property's type — wrong-typed branches won't compile.
+
+### Default (`ELSE`)
+
+`default { ... }` is optional. Without it, rows whose discriminator matches
+no branch fall through to SQL `NULL`, which is falsy in `WHERE` — those
+rows are excluded. With it, the default predicate runs.
+
+### `caseWhere` vs `case { }`
+
+| Use… | When |
+|---|---|
+| `case { whenIs<V>(path) }` | You need a *value* (for `eq` / `gt` / `ORDER BY` against a single RHS). |
+| `caseWhere { whenIs<V> { pred } }` | You need a *predicate* (different operator and/or RHS per variant). |
+
+`caseWhere` is **WHERE-only.** Predicates have no ordering, so there is no
+`OrderBy(caseWhere(...), ...)` form — use the value-selection `case` for
+that.
+
+{: .note }
+> Branch predicates lower to `json_extract` (scalar) rather than the
+> `json_tree` LATERAL joins used by top-level `eq`/`gt`/etc. For one-shot
+> boolean tests this is fine, but indexed scans on a generated column may
+> be slower for branch predicates than for top-level ones. See
+> [Performance]({{ '/guides/performance/' | relative_url }}) if your
+> store grows.
 
 ## Common pitfalls
 

--- a/docs/guides/serialization-tips.md
+++ b/docs/guides/serialization-tips.md
@@ -105,6 +105,10 @@ per variant** (e.g. `Active.activatedAt` vs `Pending.requestedAt`), use a
 `CaseWhen<T>` — see
 [Querying → CASE / WHEN]({{ '/guides/querying/#case--when-per-variant-path-selection' | relative_url }}).
 
+For the inverse case — same field name across variants but **different
+predicates** per variant (different operators, different RHS types) — see
+[Querying → CASE / WHEN: per-variant predicate selection]({{ '/guides/querying/#case--when-per-variant-predicate-selection' | relative_url }}).
+
 ## Polymorphism in stores
 
 You can open a `KeyValueStorage<Card>` and put both `CreditCard` and

--- a/docs/guides/serialization-tips.md
+++ b/docs/guides/serialization-tips.md
@@ -100,6 +100,11 @@ See the [Querying guide]({{ '/guides/querying/' | relative_url }}) and
 [Nested fields]({{ '/guides/nested-fields/' | relative_url }}) for the
 full path-builder API.
 
+When you need to filter or order by a value whose **field name differs
+per variant** (e.g. `Active.activatedAt` vs `Pending.requestedAt`), use a
+`CaseWhen<T>` — see
+[Querying → CASE / WHEN]({{ '/guides/querying/#case--when-per-variant-path-selection' | relative_url }}).
+
 ## Polymorphism in stores
 
 You can open a `KeyValueStorage<Card>` and put both `CreditCard` and

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KProperty1
  * or KClass. Use as the LHS of a comparison operator (`eq`, `gt`, …) to produce a [Where], or
  * pass to [OrderBy] to drive ordering.
  */
-class CaseWhen<T : Any> internal constructor(
+data class CaseWhen<T : Any> internal constructor(
     private val discriminatorPath: String,
     private val branches: List<Branch>,
     private val elseValuePath: String?,
@@ -17,18 +17,13 @@ class CaseWhen<T : Any> internal constructor(
     @PublishedApi
     internal data class Branch(val discriminatorValue: String, val valuePath: String)
 
-    internal fun toSqlValue(): SqlValueFragment {
+    private val fragment: SqlValueFragment by lazy {
         require(branches.isNotEmpty()) { "CaseWhen requires at least one whenIs branch" }
-        val parts = mutableListOf<String>()
-        branches.forEach { _ ->
-            parts += "WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?)"
-        }
-        if (elseValuePath != null) parts += "ELSE json_extract(entity.value, ?)"
-        val sql = "(CASE ${parts.joinToString(" ")} END)"
-        val parameters = branches.size * 3 + (if (elseValuePath != null) 1 else 0)
-        return SqlValueFragment(
-            sql = sql,
-            parameters = parameters,
+        val whenSql = "WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?)"
+        val elseSql = elseValuePath?.let { " ELSE json_extract(entity.value, ?)" } ?: ""
+        SqlValueFragment(
+            sql = "(CASE ${branches.joinToString(" ") { whenSql }}$elseSql END)",
+            parameters = branches.size * 3 + (if (elseValuePath != null) 1 else 0),
             bindArgs = {
                 branches.forEach { branch ->
                     bindString(discriminatorPath)
@@ -39,6 +34,8 @@ class CaseWhen<T : Any> internal constructor(
             },
         )
     }
+
+    internal fun toSqlValue(): SqlValueFragment = fragment
 }
 
 internal data class SqlValueFragment(
@@ -86,6 +83,8 @@ inline fun <reified T : Any, reified S : Any> KProperty1<T, S>.case(
 /**
  * `CASE WHEN` expression rooted at the entity itself when it is a sealed type
  * (e.g. `KeyValueStorage<BaseSealed>`). Discriminator path is `$[0]`, payload is under `$[1]`.
+ *
+ * The receiver provides the type anchor `R` for inference; its identity is unused at runtime.
  */
 @Suppress("UnusedReceiverParameter")
 inline fun <reified R : Any> KClass<R>.case(

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -1,6 +1,7 @@
 package com.mercury.sqkon.db
 
 import kotlinx.serialization.serializer
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
 /**
@@ -81,3 +82,15 @@ inline fun <reified T : Any, reified S : Any> KProperty1<T, S>.case(
     val discriminatorPath = parentPath.removeSuffix("[1]") + "[0]"
     return CaseWhenBuilder<T>(discriminatorPath).apply(block).build()
 }
+
+/**
+ * `CASE WHEN` expression rooted at the entity itself when it is a sealed type
+ * (e.g. `KeyValueStorage<BaseSealed>`). Discriminator path is `$[0]`, payload is under `$[1]`.
+ */
+@Suppress("UnusedReceiverParameter")
+inline fun <reified R : Any> KClass<R>.case(
+    block: CaseWhenBuilder<R>.() -> Unit,
+): CaseWhen<R> {
+    return CaseWhenBuilder<R>(discriminatorPath = "\$[0]").apply(block).build()
+}
+

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -58,6 +58,7 @@ class CaseWhenBuilder<T : Any> @PublishedApi internal constructor(
     }
 
     fun elseValue(valuePath: JsonPathBuilder<T>) {
+        require(elseValuePath == null) { "elseValue() may only be called once" }
         elseValuePath = valuePath.buildPath()
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -17,16 +17,24 @@ class CaseWhen<T : Any> internal constructor(
     internal data class Branch(val discriminatorValue: String, val valuePath: String)
 
     internal fun toSqlValue(): SqlValueFragment {
-        // Minimal impl for Task 2: only single-branch, no ELSE. Generalized in Task 3.
-        val branch = branches.single()
-        require(elseValuePath == null) { "ELSE branch not yet supported" }
+        require(branches.isNotEmpty()) { "CaseWhen requires at least one whenIs branch" }
+        val parts = mutableListOf<String>()
+        branches.forEach { _ ->
+            parts += "WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?)"
+        }
+        if (elseValuePath != null) parts += "ELSE json_extract(entity.value, ?)"
+        val sql = "(CASE ${parts.joinToString(" ")} END)"
+        val parameters = branches.size * 3 + (if (elseValuePath != null) 1 else 0)
         return SqlValueFragment(
-            sql = "(CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END)",
-            parameters = 3,
+            sql = sql,
+            parameters = parameters,
             bindArgs = {
-                bindString(discriminatorPath)
-                bindString(branch.discriminatorValue)
-                bindString(branch.valuePath)
+                branches.forEach { branch ->
+                    bindString(discriminatorPath)
+                    bindString(branch.discriminatorValue)
+                    bindString(branch.valuePath)
+                }
+                elseValuePath?.let { bindString(it) }
             },
         )
     }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -38,7 +38,7 @@ data class CaseWhen<T : Any> internal constructor(
     internal fun toSqlValue(): SqlValueFragment = fragment
 }
 
-internal data class SqlValueFragment(
+data class SqlValueFragment(
     val sql: String,
     val parameters: Int,
     val bindArgs: AutoIncrementSqlPreparedStatement.() -> Unit,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhen.kt
@@ -1,0 +1,75 @@
+package com.mercury.sqkon.db
+
+import kotlinx.serialization.serializer
+import kotlin.reflect.KProperty1
+
+/**
+ * A SQL `CASE … WHEN … END` value expression. Build via [case] on a sealed parent property
+ * or KClass. Use as the LHS of a comparison operator (`eq`, `gt`, …) to produce a [Where], or
+ * pass to [OrderBy] to drive ordering.
+ */
+class CaseWhen<T : Any> internal constructor(
+    private val discriminatorPath: String,
+    private val branches: List<Branch>,
+    private val elseValuePath: String?,
+) {
+    @PublishedApi
+    internal data class Branch(val discriminatorValue: String, val valuePath: String)
+
+    internal fun toSqlValue(): SqlValueFragment {
+        // Minimal impl for Task 2: only single-branch, no ELSE. Generalized in Task 3.
+        val branch = branches.single()
+        require(elseValuePath == null) { "ELSE branch not yet supported" }
+        return SqlValueFragment(
+            sql = "(CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END)",
+            parameters = 3,
+            bindArgs = {
+                bindString(discriminatorPath)
+                bindString(branch.discriminatorValue)
+                bindString(branch.valuePath)
+            },
+        )
+    }
+}
+
+internal data class SqlValueFragment(
+    val sql: String,
+    val parameters: Int,
+    val bindArgs: AutoIncrementSqlPreparedStatement.() -> Unit,
+)
+
+class CaseWhenBuilder<T : Any> @PublishedApi internal constructor(
+    @PublishedApi internal val discriminatorPath: String,
+) {
+    @PublishedApi internal val branches: MutableList<CaseWhen.Branch> = mutableListOf()
+    @PublishedApi internal var elseValuePath: String? = null
+
+    inline fun <reified V : Any> whenIs(valuePath: JsonPathBuilder<T>) {
+        branches += CaseWhen.Branch(
+            discriminatorValue = serializer<V>().descriptor.serialName,
+            valuePath = valuePath.buildPath(),
+        )
+    }
+
+    fun elseValue(valuePath: JsonPathBuilder<T>) {
+        elseValuePath = valuePath.buildPath()
+    }
+
+    @PublishedApi internal fun build(): CaseWhen<T> =
+        CaseWhen(discriminatorPath, branches.toList(), elseValuePath)
+}
+
+/**
+ * `CASE WHEN` expression rooted at a sealed parent property (e.g. `MyEntity::status`).
+ * The variant discriminator is read from `<parentPath>[0]`; payload paths sit under `[1]`.
+ */
+inline fun <reified T : Any, reified S : Any> KProperty1<T, S>.case(
+    block: CaseWhenBuilder<T>.() -> Unit,
+): CaseWhen<T> {
+    val parentPath = this.builder<T, S>().buildPath()
+    require(parentPath.endsWith("[1]")) {
+        "case() must be called on a sealed property; got path $parentPath"
+    }
+    val discriminatorPath = parentPath.removeSuffix("[1]") + "[0]"
+    return CaseWhenBuilder<T>(discriminatorPath).apply(block).build()
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -23,7 +23,7 @@ class CaseWhere<T : Any> internal constructor(
 
     @PublishedApi
     internal data class Branch<T : Any>(
-        val discriminatorValue: String,
+        val discriminatorValue: Any?,
         val predicate: Where<T>,
     )
 
@@ -43,7 +43,7 @@ class CaseWhere<T : Any> internal constructor(
             val capturedPred = pred
             binders += {
                 bindString(discriminatorPath)
-                bindString(capturedDiscValue)
+                bindValue(capturedDiscValue)
                 capturedPred.bindArgs(this)
             }
         }
@@ -154,7 +154,7 @@ class CaseWhereOnBuilder<T : Any, K> @PublishedApi internal constructor(
 
     fun whenEq(value: K, block: () -> Where<T>) {
         branches += CaseWhere.Branch(
-            discriminatorValue = bindableForm(value),
+            discriminatorValue = value,
             predicate = block(),
         )
     }
@@ -167,21 +167,6 @@ class CaseWhereOnBuilder<T : Any, K> @PublishedApi internal constructor(
 
     @PublishedApi internal fun build(): CaseWhere<T> =
         CaseWhere(discriminatorPath, branches.toList(), default)
-
-    /**
-     * Render an enum/value as the string sqkon binds elsewhere. Enums use
-     * Kotlin `name` (matching `bindValue` in `QueryExt.kt`); other types use
-     * `toString()`.
-     *
-     * NOTE: `@SerialName` on enum constants is not yet honored at the binding
-     * layer. If you renamed an enum case with `@SerialName`, dispatch by the
-     * original Kotlin name for now.
-     */
-    @PublishedApi
-    internal fun bindableForm(value: K): String = when (value) {
-        is Enum<*> -> value.name
-        else -> value.toString()
-    }
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -27,7 +27,7 @@ class CaseWhere<T : Any> internal constructor(
         val predicate: Where<T>,
     )
 
-    private fun buildFragment(): SqlValueFragment {
+    private val fragment: SqlValueFragment by lazy {
         require(branches.isNotEmpty() || defaultPredicate != null) {
             "caseWhere requires at least one whenIs/whenEq branch or a default { }"
         }
@@ -54,7 +54,7 @@ class CaseWhere<T : Any> internal constructor(
             binders += { pred.bindArgs(this) }
         }
 
-        return SqlValueFragment(
+        SqlValueFragment(
             sql = "(CASE ${parts.joinToString(" ")} END)",
             parameters = paramCount,
             bindArgs = { binders.forEach { it(this) } },
@@ -62,16 +62,15 @@ class CaseWhere<T : Any> internal constructor(
     }
 
     override fun toSqlQuery(increment: Int): SqlQuery {
-        val frag = buildFragment()
         return SqlQuery(
             from = null,
-            where = frag.sql,
-            parameters = frag.parameters,
-            bindArgs = frag.bindArgs,
+            where = fragment.sql,
+            parameters = fragment.parameters,
+            bindArgs = fragment.bindArgs,
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = buildFragment()
+    override fun toScalarSqlValue(): SqlValueFragment = fragment
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -152,3 +152,60 @@ inline fun <reified R : Any> KClass<R>.caseWhere(
     discriminatorPath = "\$[0]",
     payloadPath = "\$[1]",
 ).apply(block).build()
+
+/**
+ * Builder for predicate-dispatch CASE/WHEN where the discriminator is an
+ * arbitrary field (enum, string, etc.). Branches are matched against the value
+ * of [discriminatorPath] for equality.
+ */
+class CaseWhereOnBuilder<T : Any, K> @PublishedApi internal constructor(
+    @PublishedApi internal val discriminatorPath: String,
+) {
+    @PublishedApi internal val branches: MutableList<CaseWhere.Branch<T>> = mutableListOf()
+    @PublishedApi internal var default: Where<T>? = null
+    @PublishedApi internal var defaultSet: Boolean = false
+
+    fun whenEq(value: K, block: () -> Where<T>) {
+        branches += CaseWhere.Branch(
+            discriminatorValue = bindableForm(value),
+            predicate = block(),
+        )
+    }
+
+    fun default(block: () -> Where<T>) {
+        require(!defaultSet) { "default { ... } may only be specified once" }
+        defaultSet = true
+        default = block()
+    }
+
+    @PublishedApi internal fun build(): CaseWhere<T> =
+        CaseWhere(discriminatorPath, branches.toList(), default)
+
+    /**
+     * Render an enum/value as the string sqkon binds elsewhere. Enums use
+     * Kotlin `name` (matching `bindValue` in `QueryExt.kt`); other types use
+     * `toString()`.
+     *
+     * NOTE: `@SerialName` on enum constants is not yet honored at the binding
+     * layer. If you renamed an enum case with `@SerialName`, dispatch by the
+     * original Kotlin name for now.
+     */
+    @PublishedApi
+    internal fun bindableForm(value: K): String = when (value) {
+        is Enum<*> -> value.name
+        else -> value.toString()
+    }
+}
+
+/**
+ * Predicate-dispatch CASE/WHEN where the discriminator is an arbitrary field
+ * (enum, string, etc.). Compile safety: the [whenEq][CaseWhereOnBuilder.whenEq]
+ * value must match the discriminator field's type.
+ */
+inline fun <reified T : Any, reified K> caseWhere(
+    discriminator: KProperty1<T, K>,
+    block: CaseWhereOnBuilder<T, K>.() -> Unit,
+): Where<T> {
+    val path = discriminator.builder<T, K>().buildPath()
+    return CaseWhereOnBuilder<T, K>(path).apply(block).build()
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -1,0 +1,154 @@
+package com.mercury.sqkon.db
+
+import kotlinx.serialization.serializer
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+/**
+ * A SQL `CASE WHEN <disc> = ? THEN <pred> [...] [ELSE <pred>] END` expression
+ * usable as a top-level [Where].
+ *
+ * Each branch holds its own [Where] predicate. At lowering time, branch
+ * predicates emit *scalar* SQL via [Where.toScalarSqlValue] so they compose
+ * inside the CASE without LATERAL `json_tree` joins.
+ *
+ * Variants/values not listed are excluded — unmatched rows fall through to
+ * SQL NULL (falsy in WHERE). Use `default { ... }` for an explicit ELSE.
+ */
+class CaseWhere<T : Any> internal constructor(
+    private val discriminatorPath: String,
+    private val branches: List<Branch<T>>,
+    private val defaultPredicate: Where<T>?,
+) : Where<T>() {
+
+    @PublishedApi
+    internal data class Branch<T : Any>(
+        val discriminatorValue: String,
+        val predicate: Where<T>,
+    )
+
+    private fun buildFragment(): SqlValueFragment {
+        require(branches.isNotEmpty() || defaultPredicate != null) {
+            "caseWhere requires at least one whenIs/whenEq branch or a default { }"
+        }
+        val parts = mutableListOf<String>()
+        var paramCount = 0
+        val binders = mutableListOf<AutoIncrementSqlPreparedStatement.() -> Unit>()
+
+        for (branch in branches) {
+            val pred = branch.predicate.toScalarSqlValue()
+            parts += "WHEN json_extract(entity.value, ?) = ? THEN ${pred.sql}"
+            paramCount += 2 + pred.parameters
+            val capturedDiscValue = branch.discriminatorValue
+            val capturedPred = pred
+            binders += {
+                bindString(discriminatorPath)
+                bindString(capturedDiscValue)
+                capturedPred.bindArgs(this)
+            }
+        }
+        defaultPredicate?.let {
+            val pred = it.toScalarSqlValue()
+            parts += "ELSE ${pred.sql}"
+            paramCount += pred.parameters
+            binders += { pred.bindArgs(this) }
+        }
+
+        return SqlValueFragment(
+            sql = "(CASE ${parts.joinToString(" ")} END)",
+            parameters = paramCount,
+            bindArgs = { binders.forEach { it(this) } },
+        )
+    }
+
+    override fun toSqlQuery(increment: Int): SqlQuery {
+        val frag = buildFragment()
+        return SqlQuery(
+            from = null,
+            where = frag.sql,
+            parameters = frag.parameters,
+            bindArgs = frag.bindArgs,
+        )
+    }
+
+    override fun toScalarSqlValue(): SqlValueFragment = buildFragment()
+}
+
+/**
+ * Typed scope inside a `whenIs<V> { ... }` branch.
+ *
+ * Exposes a narrowed `with(KProperty1<V, X>)` (via the [with] extension below)
+ * so users can only reach into the variant's own properties —
+ * `with(OtherVariant::field)` won't compile.
+ */
+class CaseWhereBranch<T : Any, V : T> @PublishedApi internal constructor(
+    @PublishedApi internal val payloadPath: String,
+)
+
+/**
+ * Reach into a property of the variant `V` from inside a `whenIs<V> { ... }`
+ * scope, producing a [JsonPathBuilder] rooted at the variant payload (e.g.
+ * `$[1].dueAt` for a sealed-root entity).
+ */
+inline fun <T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
+    prop: KProperty1<V, X>,
+): JsonPathBuilder<T> {
+    val propPath = prop.builder().buildPath().removePrefix("\$")
+    val builder = JsonPathBuilder<T>()
+    builder.rawPath = payloadPath + propPath
+    return builder
+}
+
+/**
+ * Nested-path variant — chains `then` onto the variant property path.
+ */
+inline fun <T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
+    prop: KProperty1<V, X>,
+    nested: JsonPathBuilder<V>.() -> JsonPathBuilder<V>,
+): JsonPathBuilder<T> {
+    val nestedPath = prop.builder<V, X>().nested().buildPath().removePrefix("\$")
+    val builder = JsonPathBuilder<T>()
+    builder.rawPath = payloadPath + nestedPath
+    return builder
+}
+
+class CaseWhereBuilder<T : Any> @PublishedApi internal constructor(
+    @PublishedApi internal val discriminatorPath: String,
+    @PublishedApi internal val payloadPath: String,
+) {
+    @PublishedApi internal val branches: MutableList<CaseWhere.Branch<T>> = mutableListOf()
+    @PublishedApi internal var default: Where<T>? = null
+    @PublishedApi internal var defaultSet: Boolean = false
+
+    inline fun <reified V : T> whenIs(block: CaseWhereBranch<T, V>.() -> Where<T>) {
+        val pred = CaseWhereBranch<T, V>(payloadPath).block()
+        branches += CaseWhere.Branch(
+            discriminatorValue = serializer<V>().descriptor.serialName,
+            predicate = pred,
+        )
+    }
+
+    fun default(block: () -> Where<T>) {
+        require(!defaultSet) { "default { ... } may only be specified once" }
+        defaultSet = true
+        default = block()
+    }
+
+    @PublishedApi internal fun build(): CaseWhere<T> =
+        CaseWhere(discriminatorPath, branches.toList(), default)
+}
+
+/**
+ * Predicate-dispatch CASE/WHEN rooted at the entity itself when it is a
+ * sealed type. Discriminator at `$[0]`, payload under `$[1]`.
+ *
+ * The receiver provides the type anchor `R` for inference; its identity is
+ * unused at runtime.
+ */
+@Suppress("UnusedReceiverParameter")
+inline fun <reified R : Any> KClass<R>.caseWhere(
+    block: CaseWhereBuilder<R>.() -> Unit,
+): Where<R> = CaseWhereBuilder<R>(
+    discriminatorPath = "\$[0]",
+    payloadPath = "\$[1]",
+).apply(block).build()

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -106,7 +106,6 @@ class CaseWhereBuilder<T : Any> @PublishedApi internal constructor(
 ) {
     @PublishedApi internal val branches: MutableList<CaseWhere.Branch<T>> = mutableListOf()
     @PublishedApi internal var default: Where<T>? = null
-    @PublishedApi internal var defaultSet: Boolean = false
 
     inline fun <reified V : T> whenIs(block: CaseWhereBranch<T, V>.() -> Where<T>) {
         val pred = CaseWhereBranch<T, V>().block()
@@ -117,8 +116,7 @@ class CaseWhereBuilder<T : Any> @PublishedApi internal constructor(
     }
 
     fun default(block: () -> Where<T>) {
-        require(!defaultSet) { "default { ... } may only be specified once" }
-        defaultSet = true
+        require(default == null) { "default { ... } may only be specified once" }
         default = block()
     }
 
@@ -150,7 +148,6 @@ class CaseWhereOnBuilder<T : Any, K> @PublishedApi internal constructor(
 ) {
     @PublishedApi internal val branches: MutableList<CaseWhere.Branch<T>> = mutableListOf()
     @PublishedApi internal var default: Where<T>? = null
-    @PublishedApi internal var defaultSet: Boolean = false
 
     fun whenEq(value: K, block: () -> Where<T>) {
         branches += CaseWhere.Branch(
@@ -160,8 +157,7 @@ class CaseWhereOnBuilder<T : Any, K> @PublishedApi internal constructor(
     }
 
     fun default(block: () -> Where<T>) {
-        require(!defaultSet) { "default { ... } may only be specified once" }
-        defaultSet = true
+        require(default == null) { "default { ... } may only be specified once" }
         default = block()
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/CaseWhere.kt
@@ -81,47 +81,36 @@ class CaseWhere<T : Any> internal constructor(
  * so users can only reach into the variant's own properties —
  * `with(OtherVariant::field)` won't compile.
  */
-class CaseWhereBranch<T : Any, V : T> @PublishedApi internal constructor(
-    @PublishedApi internal val payloadPath: String,
-)
+class CaseWhereBranch<T : Any, V : T> @PublishedApi internal constructor()
 
 /**
  * Reach into a property of the variant `V` from inside a `whenIs<V> { ... }`
  * scope, producing a [JsonPathBuilder] rooted at the variant payload (e.g.
  * `$[1].dueAt` for a sealed-root entity).
  */
-inline fun <T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
+@Suppress("UnusedReceiverParameter")
+inline fun <reified T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
     prop: KProperty1<V, X>,
-): JsonPathBuilder<T> {
-    val propPath = prop.builder().buildPath().removePrefix("\$")
-    val builder = JsonPathBuilder<T>()
-    builder.rawPath = payloadPath + propPath
-    return builder
-}
+): JsonPathBuilder<T> = T::class.with(prop)
 
 /**
  * Nested-path variant — chains `then` onto the variant property path.
  */
-inline fun <T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
+@Suppress("UnusedReceiverParameter")
+inline fun <reified T : Any, reified V : T, reified X> CaseWhereBranch<T, V>.with(
     prop: KProperty1<V, X>,
-    nested: JsonPathBuilder<V>.() -> JsonPathBuilder<V>,
-): JsonPathBuilder<T> {
-    val nestedPath = prop.builder<V, X>().nested().buildPath().removePrefix("\$")
-    val builder = JsonPathBuilder<T>()
-    builder.rawPath = payloadPath + nestedPath
-    return builder
-}
+    noinline block: JsonPathNode<T, X>.() -> Unit,
+): JsonPathBuilder<T> = T::class.with(prop, block = block)
 
 class CaseWhereBuilder<T : Any> @PublishedApi internal constructor(
     @PublishedApi internal val discriminatorPath: String,
-    @PublishedApi internal val payloadPath: String,
 ) {
     @PublishedApi internal val branches: MutableList<CaseWhere.Branch<T>> = mutableListOf()
     @PublishedApi internal var default: Where<T>? = null
     @PublishedApi internal var defaultSet: Boolean = false
 
     inline fun <reified V : T> whenIs(block: CaseWhereBranch<T, V>.() -> Where<T>) {
-        val pred = CaseWhereBranch<T, V>(payloadPath).block()
+        val pred = CaseWhereBranch<T, V>().block()
         branches += CaseWhere.Branch(
             discriminatorValue = serializer<V>().descriptor.serialName,
             predicate = pred,
@@ -150,7 +139,6 @@ inline fun <reified R : Any> KClass<R>.caseWhere(
     block: CaseWhereBuilder<R>.() -> Unit,
 ): Where<R> = CaseWhereBuilder<R>(
     discriminatorPath = "\$[0]",
-    payloadPath = "\$[1]",
 ).apply(block).build()
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -44,14 +44,6 @@ class JsonPathBuilder<R : Any>
     @PublishedApi
     internal var parentNode: JsonPathNode<R, *>? = null
 
-    /**
-     * Optional precomputed path override. When set, [buildPath] short-circuits
-     * to this string instead of walking [parentNode]. Used by call sites that
-     * synthesize a path from a string (e.g. variant payload roots in CaseWhere).
-     */
-    @PublishedApi
-    internal var rawPath: String? = null
-
     @PublishedApi
     internal inline fun <reified R1 : R, reified V> with(
         property: KProperty1<R, V>,
@@ -138,7 +130,6 @@ class JsonPathBuilder<R : Any>
     }
 
     fun buildPath(): String {
-        rawPath?.let { return it }
         return fieldNames().joinToString("", prefix = "\$")
     }
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -44,6 +44,14 @@ class JsonPathBuilder<R : Any>
     @PublishedApi
     internal var parentNode: JsonPathNode<R, *>? = null
 
+    /**
+     * Optional precomputed path override. When set, [buildPath] short-circuits
+     * to this string instead of walking [parentNode]. Used by call sites that
+     * synthesize a path from a string (e.g. variant payload roots in CaseWhere).
+     */
+    @PublishedApi
+    internal var rawPath: String? = null
+
     @PublishedApi
     internal inline fun <reified R1 : R, reified V> with(
         property: KProperty1<R, V>,
@@ -130,6 +138,7 @@ class JsonPathBuilder<R : Any>
     }
 
     fun buildPath(): String {
+        rawPath?.let { return it }
         return fieldNames().joinToString("", prefix = "\$")
     }
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -401,18 +401,19 @@ internal fun List<SqlQuery>.identifier(): Int = fold(0) { acc, sqlQuery ->
     31 * acc + sqlQuery.identifier()
 }
 
-// ---- CASE / WHEN comparison operators ----
+private enum class CaseOp(val sql: String) { EQ("="), NEQ("!="), GT(">"), LT("<") }
+private enum class CaseNullOp(val sql: String) { IS_NULL("IS NULL"), IS_NOT_NULL("IS NOT NULL") }
 
 private fun <T : Any, V> caseCompare(
     case: CaseWhen<T>,
-    sqlOp: String,
+    op: CaseOp,
     value: V?,
 ): Where<T> = object : Where<T>() {
     override fun toSqlQuery(increment: Int): SqlQuery {
         val frag = case.toSqlValue()
         return SqlQuery(
             from = null,
-            where = "(${frag.sql} $sqlOp ?)",
+            where = "(${frag.sql} ${op.sql} ?)",
             parameters = frag.parameters + 1,
             bindArgs = {
                 frag.bindArgs(this)
@@ -424,28 +425,26 @@ private fun <T : Any, V> caseCompare(
 
 private fun <T : Any> caseUnary(
     case: CaseWhen<T>,
-    suffix: String,
+    op: CaseNullOp,
 ): Where<T> = object : Where<T>() {
     override fun toSqlQuery(increment: Int): SqlQuery {
         val frag = case.toSqlValue()
         return SqlQuery(
             from = null,
-            where = "(${frag.sql} $suffix)",
+            where = "(${frag.sql} ${op.sql})",
             parameters = frag.parameters,
             bindArgs = { frag.bindArgs(this) },
         )
     }
 }
 
-infix fun <T : Any, V> CaseWhen<T>.eq(value: V?): Where<T> = caseCompare(this, "=", value)
-infix fun <T : Any, V> CaseWhen<T>.neq(value: V?): Where<T> = caseCompare(this, "!=", value)
-infix fun <T : Any, V> CaseWhen<T>.gt(value: V?): Where<T> = caseCompare(this, ">", value)
-infix fun <T : Any, V> CaseWhen<T>.gte(value: V?): Where<T> = caseCompare(this, ">=", value)
-infix fun <T : Any, V> CaseWhen<T>.lt(value: V?): Where<T> = caseCompare(this, "<", value)
-infix fun <T : Any, V> CaseWhen<T>.lte(value: V?): Where<T> = caseCompare(this, "<=", value)
+infix fun <T : Any, V> CaseWhen<T>.eq(value: V?): Where<T> = caseCompare(this, CaseOp.EQ, value)
+infix fun <T : Any, V> CaseWhen<T>.neq(value: V?): Where<T> = caseCompare(this, CaseOp.NEQ, value)
+infix fun <T : Any, V> CaseWhen<T>.gt(value: V?): Where<T> = caseCompare(this, CaseOp.GT, value)
+infix fun <T : Any, V> CaseWhen<T>.lt(value: V?): Where<T> = caseCompare(this, CaseOp.LT, value)
 
-fun <T : Any> CaseWhen<T>.isNull(): Where<T> = caseUnary(this, "IS NULL")
-fun <T : Any> CaseWhen<T>.isNotNull(): Where<T> = caseUnary(this, "IS NOT NULL")
+fun <T : Any> CaseWhen<T>.isNull(): Where<T> = caseUnary(this, CaseNullOp.IS_NULL)
+fun <T : Any> CaseWhen<T>.isNotNull(): Where<T> = caseUnary(this, CaseNullOp.IS_NOT_NULL)
 
 class AutoIncrementSqlPreparedStatement(
     private var index: Int = 0,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -22,14 +22,21 @@ data class Eq<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
-        sql = "(json_extract(entity.value, ?) = ?)",
-        parameters = 2,
-        bindArgs = {
-            bindString(builder.buildPath())
-            bindValue(value)
-        },
-    )
+    override fun toScalarSqlValue(): SqlValueFragment {
+        if (value == null) return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) IS NULL)",
+            parameters = 1,
+            bindArgs = { bindString(builder.buildPath()) },
+        )
+        return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) = ?)",
+            parameters = 2,
+            bindArgs = {
+                bindString(builder.buildPath())
+                bindValue(value)
+            },
+        )
+    }
 }
 
 /**
@@ -63,14 +70,21 @@ data class NotEq<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
-        sql = "(json_extract(entity.value, ?) != ?)",
-        parameters = 2,
-        bindArgs = {
-            bindString(builder.buildPath())
-            bindValue(value)
-        },
-    )
+    override fun toScalarSqlValue(): SqlValueFragment {
+        if (value == null) return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) IS NOT NULL)",
+            parameters = 1,
+            bindArgs = { bindString(builder.buildPath()) },
+        )
+        return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) != ?)",
+            parameters = 2,
+            bindArgs = {
+                bindString(builder.buildPath())
+                bindValue(value)
+            },
+        )
+    }
 }
 
 /**
@@ -210,8 +224,14 @@ data class GreaterThan<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) > ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindValue(value)
+        },
+    )
 }
 
 /**
@@ -247,8 +267,14 @@ data class LessThan<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) < ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindValue(value)
+        },
+    )
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -307,8 +307,14 @@ data class Not<T : Any>(private val where: Where<T>) : Where<T>() {
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment {
+        val inner = where.toScalarSqlValue()
+        return SqlValueFragment(
+            sql = "(NOT ${inner.sql})",
+            parameters = inner.parameters,
+            bindArgs = { inner.bindArgs(this) },
+        )
+    }
 }
 
 /**
@@ -326,8 +332,15 @@ data class And<T : Any>(private val left: Where<T>, private val right: Where<T>)
         return SqlQuery(leftQuery, rightQuery, operator = "AND")
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment {
+        val l = left.toScalarSqlValue()
+        val r = right.toScalarSqlValue()
+        return SqlValueFragment(
+            sql = "(${l.sql} AND ${r.sql})",
+            parameters = l.parameters + r.parameters,
+            bindArgs = { l.bindArgs(this); r.bindArgs(this) },
+        )
+    }
 }
 
 /**
@@ -345,8 +358,15 @@ data class Or<T : Any>(private val left: Where<T>, private val right: Where<T>) 
         return SqlQuery(leftQuery, rightQuery, operator = "OR")
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment {
+        val l = left.toScalarSqlValue()
+        val r = right.toScalarSqlValue()
+        return SqlValueFragment(
+            sql = "(${l.sql} OR ${r.sql})",
+            parameters = l.parameters + r.parameters,
+            bindArgs = { l.bindArgs(this); r.bindArgs(this) },
+        )
+    }
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -118,8 +118,22 @@ data class In<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment {
+        if (value.isEmpty()) return SqlValueFragment(
+            sql = "(0)",
+            parameters = 0,
+            bindArgs = {},
+        )
+        val placeholders = value.joinToString(", ") { "?" }
+        return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) IN ($placeholders))",
+            parameters = 1 + value.size,
+            bindArgs = {
+                bindString(builder.buildPath())
+                value.forEach { bindValue(it) }
+            },
+        )
+    }
 }
 
 data class NotIn<T : Any, V>(
@@ -138,8 +152,22 @@ data class NotIn<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment {
+        if (value.isEmpty()) return SqlValueFragment(
+            sql = "(1)",
+            parameters = 0,
+            bindArgs = {},
+        )
+        val placeholders = value.joinToString(", ") { "?" }
+        return SqlValueFragment(
+            sql = "(json_extract(entity.value, ?) NOT IN ($placeholders))",
+            parameters = 1 + value.size,
+            bindArgs = {
+                bindString(builder.buildPath())
+                value.forEach { bindValue(it) }
+            },
+        )
+    }
 }
 
 
@@ -186,8 +214,14 @@ data class Like<T : Any>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment =
-        TODO("scalar form not yet implemented")
+    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) LIKE ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindString(value)
+        },
+    )
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -538,6 +538,25 @@ private fun <T : Any, V> caseCompare(
     case: CaseWhen<T>,
     op: CaseOp,
     value: V?,
+): Where<T> {
+    // SQLite `<expr> = NULL` / `<expr> != NULL` are always NULL (never true). For
+    // `case eq null` / `case neq null` fall through to the unary IS NULL / IS NOT NULL
+    // form so the predicate matches expected null semantics. Other ops (gt/lt) keep
+    // binding the RHS — comparing to a null bound there is a caller bug, not ours to mask.
+    if (value == null) {
+        when (op) {
+            CaseOp.EQ -> return caseUnary(case, CaseNullOp.IS_NULL)
+            CaseOp.NEQ -> return caseUnary(case, CaseNullOp.IS_NOT_NULL)
+            CaseOp.GT, CaseOp.LT -> { /* fall through to bound form */ }
+        }
+    }
+    return caseCompareBound(case, op, value)
+}
+
+private fun <T : Any, V> caseCompareBound(
+    case: CaseWhen<T>,
+    op: CaseOp,
+    value: V?,
 ): Where<T> = object : Where<T>() {
     private fun fragment(): SqlValueFragment {
         val frag = case.toSqlValue()

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -367,6 +367,52 @@ internal fun List<SqlQuery>.identifier(): Int = fold(0) { acc, sqlQuery ->
     31 * acc + sqlQuery.identifier()
 }
 
+// ---- CASE / WHEN comparison operators ----
+
+private fun <T : Any, V> caseCompare(
+    case: CaseWhen<T>,
+    sqlOp: String,
+    value: V?,
+): Where<T> = object : Where<T>() {
+    override fun toSqlQuery(increment: Int): SqlQuery {
+        val frag = case.toSqlValue()
+        return SqlQuery(
+            from = null,
+            where = "(${frag.sql} $sqlOp ?)",
+            parameters = frag.parameters + 1,
+            bindArgs = {
+                frag.bindArgs(this)
+                bindValue(value)
+            },
+        )
+    }
+}
+
+private fun <T : Any> caseUnary(
+    case: CaseWhen<T>,
+    suffix: String,
+): Where<T> = object : Where<T>() {
+    override fun toSqlQuery(increment: Int): SqlQuery {
+        val frag = case.toSqlValue()
+        return SqlQuery(
+            from = null,
+            where = "(${frag.sql} $suffix)",
+            parameters = frag.parameters,
+            bindArgs = { frag.bindArgs(this) },
+        )
+    }
+}
+
+infix fun <T : Any, V> CaseWhen<T>.eq(value: V?): Where<T> = caseCompare(this, "=", value)
+infix fun <T : Any, V> CaseWhen<T>.neq(value: V?): Where<T> = caseCompare(this, "!=", value)
+infix fun <T : Any, V> CaseWhen<T>.gt(value: V?): Where<T> = caseCompare(this, ">", value)
+infix fun <T : Any, V> CaseWhen<T>.gte(value: V?): Where<T> = caseCompare(this, ">=", value)
+infix fun <T : Any, V> CaseWhen<T>.lt(value: V?): Where<T> = caseCompare(this, "<", value)
+infix fun <T : Any, V> CaseWhen<T>.lte(value: V?): Where<T> = caseCompare(this, "<=", value)
+
+fun <T : Any> CaseWhen<T>.isNull(): Where<T> = caseUnary(this, "IS NULL")
+fun <T : Any> CaseWhen<T>.isNotNull(): Where<T> = caseUnary(this, "IS NOT NULL")
+
 class AutoIncrementSqlPreparedStatement(
     private var index: Int = 0,
     private val preparedStatement: SqlPreparedStatement,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -21,6 +21,15 @@ data class Eq<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) = ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindValue(value)
+        },
+    )
 }
 
 /**
@@ -53,6 +62,15 @@ data class NotEq<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) != ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindValue(value)
+        },
+    )
 }
 
 /**
@@ -85,6 +103,9 @@ data class In<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 data class NotIn<T : Any, V>(
@@ -102,6 +123,9 @@ data class NotIn<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 
@@ -147,6 +171,9 @@ data class Like<T : Any>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -182,6 +209,9 @@ data class GreaterThan<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -216,6 +246,9 @@ data class LessThan<T : Any, V>(
             }
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -247,6 +280,9 @@ data class Not<T : Any>(private val where: Where<T>) : Where<T>() {
             orderBy = query.orderBy
         )
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -263,6 +299,9 @@ data class And<T : Any>(private val left: Where<T>, private val right: Where<T>)
         val rightQuery = right.toSqlQuery((increment * 10) + 1)
         return SqlQuery(leftQuery, rightQuery, operator = "AND")
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -279,6 +318,9 @@ data class Or<T : Any>(private val left: Where<T>, private val right: Where<T>) 
         val rightQuery = right.toSqlQuery((increment * 10) + 1)
         return SqlQuery(leftQuery, rightQuery, operator = "OR")
     }
+
+    override fun toScalarSqlValue(): SqlValueFragment =
+        TODO("scalar form not yet implemented")
 }
 
 /**
@@ -287,7 +329,14 @@ data class Or<T : Any>(private val left: Where<T>, private val right: Where<T>) 
 infix fun <T : Any> Where<T>.or(other: Where<T>): Where<T> = Or(this, other)
 
 abstract class Where<T : Any> {
-    abstract fun toSqlQuery(increment: Int): SqlQuery
+    internal abstract fun toSqlQuery(increment: Int): SqlQuery
+
+    /**
+     * Emits a scalar boolean SQL fragment using `json_extract` (no LATERAL joins).
+     * Used when this Where appears inside a CASE expression branch where row-level
+     * dispatch is required.
+     */
+    internal abstract fun toScalarSqlValue(): SqlValueFragment
 }
 
 sealed class OrderBy<T : Any> {
@@ -409,11 +458,10 @@ private fun <T : Any, V> caseCompare(
     op: CaseOp,
     value: V?,
 ): Where<T> = object : Where<T>() {
-    override fun toSqlQuery(increment: Int): SqlQuery {
+    private fun fragment(): SqlValueFragment {
         val frag = case.toSqlValue()
-        return SqlQuery(
-            from = null,
-            where = "(${frag.sql} ${op.sql} ?)",
+        return SqlValueFragment(
+            sql = "(${frag.sql} ${op.sql} ?)",
             parameters = frag.parameters + 1,
             bindArgs = {
                 frag.bindArgs(this)
@@ -421,21 +469,44 @@ private fun <T : Any, V> caseCompare(
             },
         )
     }
+
+    override fun toSqlQuery(increment: Int): SqlQuery {
+        val frag = fragment()
+        return SqlQuery(
+            from = null,
+            where = frag.sql,
+            parameters = frag.parameters,
+            bindArgs = frag.bindArgs,
+        )
+    }
+
+    override fun toScalarSqlValue(): SqlValueFragment = fragment()
 }
 
 private fun <T : Any> caseUnary(
     case: CaseWhen<T>,
     op: CaseNullOp,
 ): Where<T> = object : Where<T>() {
-    override fun toSqlQuery(increment: Int): SqlQuery {
+    private fun fragment(): SqlValueFragment {
         val frag = case.toSqlValue()
-        return SqlQuery(
-            from = null,
-            where = "(${frag.sql} ${op.sql})",
+        return SqlValueFragment(
+            sql = "(${frag.sql} ${op.sql})",
             parameters = frag.parameters,
             bindArgs = { frag.bindArgs(this) },
         )
     }
+
+    override fun toSqlQuery(increment: Int): SqlQuery {
+        val frag = fragment()
+        return SqlQuery(
+            from = null,
+            where = frag.sql,
+            parameters = frag.parameters,
+            bindArgs = frag.bindArgs,
+        )
+    }
+
+    override fun toScalarSqlValue(): SqlValueFragment = fragment()
 }
 
 infix fun <T : Any, V> CaseWhen<T>.eq(value: V?): Where<T> = caseCompare(this, CaseOp.EQ, value)

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -388,14 +388,14 @@ data class Or<T : Any>(private val left: Where<T>, private val right: Where<T>) 
 infix fun <T : Any> Where<T>.or(other: Where<T>): Where<T> = Or(this, other)
 
 abstract class Where<T : Any> {
-    internal abstract fun toSqlQuery(increment: Int): SqlQuery
+    abstract fun toSqlQuery(increment: Int): SqlQuery
 
     /**
      * Emits a scalar boolean SQL fragment using `json_extract` (no LATERAL joins).
      * Used when this Where appears inside a CASE expression branch where row-level
      * dispatch is required.
      */
-    internal abstract fun toScalarSqlValue(): SqlValueFragment
+    abstract fun toScalarSqlValue(): SqlValueFragment
 }
 
 sealed class OrderBy<T : Any> {

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -290,19 +290,62 @@ abstract class Where<T : Any> {
     abstract fun toSqlQuery(increment: Int): SqlQuery
 }
 
-data class OrderBy<T : Any>(
+sealed class OrderBy<T : Any> {
+    internal abstract val direction: OrderDirection?
+    internal abstract fun toSqlQuery(index: Int): SqlQuery
+}
+
+data class JsonPathOrderBy<T : Any> @PublishedApi internal constructor(
     private val builder: JsonPathBuilder<T>,
     /**
      * Sqlite defaults to ASC when not specified
      */
-    internal val direction: OrderDirection? = null,
-) {
-    val path: String = builder.buildPath()
+    override val direction: OrderDirection? = null,
+) : OrderBy<T>() {
+    private val path: String = builder.buildPath()
+
+    override fun toSqlQuery(index: Int): SqlQuery {
+        val treeName = "order_$index"
+        return SqlQuery(
+            from = "json_tree(entity.value, '$') as $treeName",
+            where = "$treeName.fullkey LIKE ?",
+            parameters = 1,
+            bindArgs = { bindString(path) },
+            orderBy = "$treeName.value ${direction?.value ?: ""}".trimEnd(),
+        )
+    }
 }
 
+data class CaseOrderBy<T : Any> internal constructor(
+    private val case: CaseWhen<T>,
+    override val direction: OrderDirection? = null,
+) : OrderBy<T>() {
+    override fun toSqlQuery(index: Int): SqlQuery {
+        val frag = case.toSqlValue()
+        return SqlQuery(
+            from = null,
+            where = null,
+            parameters = frag.parameters,
+            bindArgs = { frag.bindArgs(this) },
+            orderBy = "${frag.sql} ${direction?.value ?: ""}".trimEnd(),
+        )
+    }
+}
+
+fun <T : Any> OrderBy(
+    builder: JsonPathBuilder<T>,
+    direction: OrderDirection? = null,
+): OrderBy<T> = JsonPathOrderBy(builder, direction)
+
 inline fun <reified T : Any, reified V> OrderBy(
-    property: KProperty1<T, V>, direction: OrderDirection? = null,
-) = OrderBy(property.builder(), direction)
+    property: KProperty1<T, V>,
+    direction: OrderDirection? = null,
+): OrderBy<T> = JsonPathOrderBy(property.builder(), direction)
+
+fun <T : Any> OrderBy(
+    case: CaseWhen<T>,
+    direction: OrderDirection? = null,
+): OrderBy<T> = CaseOrderBy(case, direction)
 
 enum class OrderDirection(val value: String) {
     ASC(value = "ASC"),
@@ -311,16 +354,7 @@ enum class OrderDirection(val value: String) {
 
 fun List<OrderBy<*>>.toSqlQueries(): List<SqlQuery> {
     if (isEmpty()) return emptyList()
-    return mapIndexed { index, orderBy ->
-        val treeName = "order_$index"
-        SqlQuery(
-            from = "json_tree(entity.value, '$') as $treeName",
-            where = "$treeName.fullkey LIKE ?",
-            parameters = 1,
-            bindArgs = { bindString(orderBy.path) },
-            orderBy = "$treeName.value ${orderBy.direction?.value ?: ""}",
-        )
-    }
+    return mapIndexed { index, orderBy -> orderBy.toSqlQuery(index) }
 }
 
 data class SqlQuery(

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -4,6 +4,57 @@ import app.cash.sqldelight.db.SqlPreparedStatement
 import kotlin.reflect.KProperty1
 
 /**
+ * Scalar `(json_extract(entity.value, ?) <op> ?)` fragment, with `IS NULL` /
+ * `IS NOT NULL` fall-through for null values when [nullOpSql] is provided.
+ */
+private fun scalarBinop(
+    builder: JsonPathBuilder<*>,
+    opSql: String,
+    value: Any?,
+    nullOpSql: String? = null,
+): SqlValueFragment {
+    if (value == null && nullOpSql != null) return SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) $nullOpSql)",
+        parameters = 1,
+        bindArgs = { bindString(builder.buildPath()) },
+    )
+    return SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) $opSql ?)",
+        parameters = 2,
+        bindArgs = {
+            bindString(builder.buildPath())
+            bindValue(value)
+        },
+    )
+}
+
+/**
+ * Scalar `(json_extract(entity.value, ?) [NOT ]IN (?, ?, ...))` fragment, with
+ * a constant short-circuit when [values] is empty.
+ */
+private fun scalarInOp(
+    builder: JsonPathBuilder<*>,
+    notIn: Boolean,
+    values: Collection<*>,
+): SqlValueFragment {
+    if (values.isEmpty()) return SqlValueFragment(
+        sql = if (notIn) "(1)" else "(0)",
+        parameters = 0,
+        bindArgs = {},
+    )
+    val placeholders = values.joinToString(", ") { "?" }
+    val keyword = if (notIn) "NOT IN" else "IN"
+    return SqlValueFragment(
+        sql = "(json_extract(entity.value, ?) $keyword ($placeholders))",
+        parameters = 1 + values.size,
+        bindArgs = {
+            bindString(builder.buildPath())
+            values.forEach { bindValue(it) }
+        },
+    )
+}
+
+/**
  * Equivalent to `=` in SQL
  */
 data class Eq<T : Any, V>(
@@ -22,21 +73,8 @@ data class Eq<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment {
-        if (value == null) return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) IS NULL)",
-            parameters = 1,
-            bindArgs = { bindString(builder.buildPath()) },
-        )
-        return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) = ?)",
-            parameters = 2,
-            bindArgs = {
-                bindString(builder.buildPath())
-                bindValue(value)
-            },
-        )
-    }
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarBinop(builder, opSql = "=", value = value, nullOpSql = "IS NULL")
 }
 
 /**
@@ -70,21 +108,8 @@ data class NotEq<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment {
-        if (value == null) return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) IS NOT NULL)",
-            parameters = 1,
-            bindArgs = { bindString(builder.buildPath()) },
-        )
-        return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) != ?)",
-            parameters = 2,
-            bindArgs = {
-                bindString(builder.buildPath())
-                bindValue(value)
-            },
-        )
-    }
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarBinop(builder, opSql = "!=", value = value, nullOpSql = "IS NOT NULL")
 }
 
 /**
@@ -118,22 +143,8 @@ data class In<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment {
-        if (value.isEmpty()) return SqlValueFragment(
-            sql = "(0)",
-            parameters = 0,
-            bindArgs = {},
-        )
-        val placeholders = value.joinToString(", ") { "?" }
-        return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) IN ($placeholders))",
-            parameters = 1 + value.size,
-            bindArgs = {
-                bindString(builder.buildPath())
-                value.forEach { bindValue(it) }
-            },
-        )
-    }
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarInOp(builder, notIn = false, values = value)
 }
 
 data class NotIn<T : Any, V>(
@@ -152,22 +163,8 @@ data class NotIn<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment {
-        if (value.isEmpty()) return SqlValueFragment(
-            sql = "(1)",
-            parameters = 0,
-            bindArgs = {},
-        )
-        val placeholders = value.joinToString(", ") { "?" }
-        return SqlValueFragment(
-            sql = "(json_extract(entity.value, ?) NOT IN ($placeholders))",
-            parameters = 1 + value.size,
-            bindArgs = {
-                bindString(builder.buildPath())
-                value.forEach { bindValue(it) }
-            },
-        )
-    }
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarInOp(builder, notIn = true, values = value)
 }
 
 
@@ -214,14 +211,8 @@ data class Like<T : Any>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
-        sql = "(json_extract(entity.value, ?) LIKE ?)",
-        parameters = 2,
-        bindArgs = {
-            bindString(builder.buildPath())
-            bindString(value)
-        },
-    )
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarBinop(builder, opSql = "LIKE", value = value)
 }
 
 /**
@@ -258,14 +249,8 @@ data class GreaterThan<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
-        sql = "(json_extract(entity.value, ?) > ?)",
-        parameters = 2,
-        bindArgs = {
-            bindString(builder.buildPath())
-            bindValue(value)
-        },
-    )
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarBinop(builder, opSql = ">", value = value)
 }
 
 /**
@@ -301,14 +286,8 @@ data class LessThan<T : Any, V>(
         )
     }
 
-    override fun toScalarSqlValue(): SqlValueFragment = SqlValueFragment(
-        sql = "(json_extract(entity.value, ?) < ?)",
-        parameters = 2,
-        bindArgs = {
-            bindString(builder.buildPath())
-            bindValue(value)
-        },
-    )
+    override fun toScalarSqlValue(): SqlValueFragment =
+        scalarBinop(builder, opSql = "<", value = value)
 }
 
 /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -61,6 +61,17 @@ data class Eq<T : Any, V>(
     private val builder: JsonPathBuilder<T>, private val value: V?,
 ) : Where<T>() {
     override fun toSqlQuery(increment: Int): SqlQuery {
+        // SQLite `<col> = NULL` always evaluates to NULL (never true), so for `eq null`
+        // we drop the json_tree join and emit `json_extract(entity.value, ?) IS NULL`
+        // — matching the scalar lowering's null special-case.
+        if (value == null) {
+            return SqlQuery(
+                from = null,
+                where = "(json_extract(entity.value, ?) IS NULL)",
+                parameters = 1,
+                bindArgs = { bindString(builder.buildPath()) },
+            )
+        }
         val treeName = "eq_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
@@ -96,6 +107,17 @@ data class NotEq<T : Any, V>(
     private val builder: JsonPathBuilder<T>, private val value: V?,
 ) : Where<T>() {
     override fun toSqlQuery(increment: Int): SqlQuery {
+        // SQLite `<col> != NULL` always evaluates to NULL (never true), so for `neq null`
+        // we drop the json_tree join and emit `json_extract(entity.value, ?) IS NOT NULL`
+        // — matching the scalar lowering's null special-case.
+        if (value == null) {
+            return SqlQuery(
+                from = null,
+                where = "(json_extract(entity.value, ?) IS NOT NULL)",
+                parameters = 1,
+                bindArgs = { bindString(builder.buildPath()) },
+            )
+        }
         val treeName = "eq_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -100,3 +100,22 @@ enum class TestEnum {
     @SerialName("unknown")
     LAST;
 }
+
+@Serializable
+sealed interface SealedTimed {
+    val id: String
+
+    @Serializable
+    @SerialName("Active")
+    data class Active(
+        override val id: String,
+        val activatedAt: Long,
+    ) : SealedTimed
+
+    @Serializable
+    @SerialName("Pending")
+    data class Pending(
+        override val id: String,
+        val requestedAt: Long,
+    ) : SealedTimed
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -119,3 +119,43 @@ sealed interface SealedTimed {
         val requestedAt: Long,
     ) : SealedTimed
 }
+
+@Serializable
+sealed interface Order {
+    val id: String
+
+    @Serializable
+    @SerialName("Active")
+    data class Active(
+        override val id: String,
+        val dueAt: Long,
+        val priority: Int,
+    ) : Order
+
+    @Serializable
+    @SerialName("Pending")
+    data class Pending(
+        override val id: String,
+        val reviewedAt: Long?,
+        val escalated: Boolean = false,
+    ) : Order
+
+    @Serializable
+    @SerialName("Cancelled")
+    data class Cancelled(
+        override val id: String,
+        val reason: String,
+    ) : Order
+}
+
+@Serializable
+enum class ShipmentStatus { KEPT, RETURNED, IN_TRANSIT }
+
+@Serializable
+data class Shipment(
+    val id: String,
+    val status: ShipmentStatus,
+    val trackerId: String? = null,
+    val returnedAt: Long? = null,
+    val flagged: Boolean = false,
+)

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -95,6 +95,41 @@ class CaseWhenSqlTest {
     }
 
     @Test
+    fun orderBy_caseExpression_emitsCaseInOrderBy() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val list: List<OrderBy<*>> = listOf(OrderBy(case, OrderDirection.DESC))
+        val queries: List<SqlQuery> = list.toSqlQueries()
+
+        assertEquals(1, queries.size)
+        val q = queries.single()
+        assertEquals(null, q.from)
+        assertEquals(null, q.where)
+        assertEquals(
+            "(CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END) DESC",
+            q.orderBy,
+        )
+        assertEquals(3, q.parameters)
+        assertEquals(
+            listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean"),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
+    fun orderBy_jsonPath_stillEmitsJsonTreeAfterRefactor() {
+        val list: List<OrderBy<*>> = listOf(OrderBy(TestObject::name, OrderDirection.ASC))
+        val q = list.toSqlQueries().single()
+
+        assertEquals("json_tree(entity.value, '\$') as order_0", q.from)
+        assertEquals("order_0.fullkey LIKE ?", q.where)
+        assertEquals("order_0.value ASC", q.orderBy)
+        assertEquals(1, q.parameters)
+    }
+
+    @Test
     fun caseIsNull_caseIsNotNull_emitNullPredicates() {
         val case = TestObject::sealed.case<TestObject, TestSealed> {
             whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -8,6 +8,7 @@ import com.mercury.sqkon.TypeOneData
 import com.mercury.sqkon.TypeTwoData
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class CaseWhenSqlTest {
 
@@ -180,6 +181,18 @@ class CaseWhenSqlTest {
         val isNotNullQ = case.isNotNull().toSqlQuery(1)
         assertEquals(true, isNotNullQ.where!!.endsWith(") IS NOT NULL)"))
         assertEquals(3, isNotNullQ.parameters)
+    }
+
+    @Test
+    fun elseValue_calledTwice_throws() {
+        val ex = assertFailsWith<IllegalArgumentException> {
+            TestObject::sealed.case<TestObject, TestSealed> {
+                whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+                elseValue(TestObject::name.builder())
+                elseValue(TestObject::description.builder())
+            }
+        }
+        assertEquals(true, ex.message!!.contains("elseValue"))
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -1,8 +1,11 @@
 package com.mercury.sqkon.db
 
 import app.cash.sqldelight.db.SqlPreparedStatement
+import com.mercury.sqkon.BaseSealed
 import com.mercury.sqkon.TestObject
 import com.mercury.sqkon.TestSealed
+import com.mercury.sqkon.TypeOneData
+import com.mercury.sqkon.TypeTwoData
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -23,6 +26,31 @@ class CaseWhenSqlTest {
         assertEquals(3, frag.parameters)
         assertEquals(
             listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean"),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+
+    @Test
+    fun case_rootSealed_viaKClass_emitsExpectedSql() {
+        val case: CaseWhen<BaseSealed> = BaseSealed::class.case {
+            whenIs<BaseSealed.TypeOne>(
+                BaseSealed::class.with(BaseSealed.TypeOne::data) { then(TypeOneData::key) }
+            )
+            whenIs<BaseSealed.TypeTwo>(
+                BaseSealed::class.with(BaseSealed.TypeTwo::data) { then(TypeTwoData::otherValue) }
+            )
+        }
+
+        val frag = case.toSqlValue()
+
+        assertEquals(6, frag.parameters)
+        assertEquals(
+            listOf(
+                // BaseSealed.TypeOne is a @JvmInline value class wrapping `data`,
+                // so JsonPath skips the wrapper -> $[1].key (not $[1].data.key).
+                "\$[0]", "TypeOne", "\$[1].key",
+                "\$[0]", "TypeTwo", "\$[1].data.otherValue",
+            ),
             captureBoundArgs(frag.parameters, frag.bindArgs),
         )
     }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -56,6 +56,60 @@ class CaseWhenSqlTest {
     }
 
     @Test
+    fun caseGt_producesExpectedWhereFragment() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val q: SqlQuery = (case gt 100L).toSqlQuery(increment = 1)
+
+        assertEquals(null, q.from)
+        assertEquals(
+            "((CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END) > ?)",
+            q.where,
+        )
+        assertEquals(4, q.parameters)
+        assertEquals(
+            listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean", 100L),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
+    fun caseEq_caseNeq_caseLt_caseLte_caseGte_emitCorrectOperators() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        fun assertEndsWith(op: String, w: Where<TestObject>) {
+            val sql = w.toSqlQuery(1).where!!
+            assertEquals(true, sql.endsWith(") $op ?)"), "expected '$sql' to end with ') $op ?)'")
+        }
+
+        assertEndsWith("=",  case eq 1L)
+        assertEndsWith("!=", case neq 1L)
+        assertEndsWith("<",  case lt 1L)
+        assertEndsWith("<=", case lte 1L)
+        assertEndsWith(">",  case gt 1L)
+        assertEndsWith(">=", case gte 1L)
+    }
+
+    @Test
+    fun caseIsNull_caseIsNotNull_emitNullPredicates() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val isNullQ = case.isNull().toSqlQuery(1)
+        assertEquals(true, isNullQ.where!!.endsWith(") IS NULL)"))
+        assertEquals(3, isNullQ.parameters)
+
+        val isNotNullQ = case.isNotNull().toSqlQuery(1)
+        assertEquals(true, isNotNullQ.where!!.endsWith(") IS NOT NULL)"))
+        assertEquals(3, isNotNullQ.parameters)
+    }
+
+    @Test
     fun case_multipleBranches_withElse_emitsExpectedSql() {
         val case: CaseWhen<TestObject> = TestObject::sealed.case<TestObject, TestSealed> {
             whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -1,0 +1,47 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.db.SqlPreparedStatement
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.TestSealed
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CaseWhenSqlTest {
+
+    @Test
+    fun case_singleBranch_emitsExpectedSql() {
+        val case: CaseWhen<TestObject> = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val frag = case.toSqlValue()
+
+        assertEquals(
+            "(CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END)",
+            frag.sql,
+        )
+        assertEquals(3, frag.parameters)
+        assertEquals(
+            listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean"),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+}
+
+/** Replays a bindArgs lambda against a recording prepared statement so tests can assert binds. */
+internal fun captureBoundArgs(
+    parameters: Int,
+    bindArgs: AutoIncrementSqlPreparedStatement.() -> Unit,
+): List<Any?> {
+    val captured = arrayOfNulls<Any?>(parameters)
+    val recorder = object : SqlPreparedStatement {
+        override fun bindBoolean(index: Int, boolean: Boolean?) { captured[index] = boolean }
+        override fun bindBytes(index: Int, bytes: ByteArray?) { captured[index] = bytes }
+        override fun bindDouble(index: Int, double: Double?) { captured[index] = double }
+        override fun bindLong(index: Int, long: Long?) { captured[index] = long }
+        override fun bindString(index: Int, string: String?) { captured[index] = string }
+    }
+    val binder = AutoIncrementSqlPreparedStatement(preparedStatement = recorder)
+    bindArgs(binder)
+    return captured.toList()
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -128,6 +128,46 @@ class CaseWhenSqlTest {
     }
 
     @Test
+    fun caseEqNull_emitsIsNullPredicate() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val q = (case eq null).toSqlQuery(increment = 1)
+
+        assertEquals(null, q.from)
+        assertEquals(
+            "((CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END) IS NULL)",
+            q.where,
+        )
+        assertEquals(3, q.parameters)
+        assertEquals(
+            listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean"),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
+    fun caseNeqNull_emitsIsNotNullPredicate() {
+        val case = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+        }
+
+        val q = (case neq null).toSqlQuery(increment = 1)
+
+        assertEquals(null, q.from)
+        assertEquals(
+            "((CASE WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) END) IS NOT NULL)",
+            q.where,
+        )
+        assertEquals(3, q.parameters)
+        assertEquals(
+            listOf("\$.sealed[0]", "Impl", "\$.sealed[1].boolean"),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
     fun caseIsNull_caseIsNotNull_emitNullPredicates() {
         val case = TestObject::sealed.case<TestObject, TestSealed> {
             whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -76,7 +76,7 @@ class CaseWhenSqlTest {
     }
 
     @Test
-    fun caseEq_caseNeq_caseLt_caseLte_caseGte_emitCorrectOperators() {
+    fun caseEq_caseNeq_caseLt_caseGt_emitCorrectOperators() {
         val case = TestObject::sealed.case<TestObject, TestSealed> {
             whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
         }
@@ -89,9 +89,7 @@ class CaseWhenSqlTest {
         assertEndsWith("=",  case eq 1L)
         assertEndsWith("!=", case neq 1L)
         assertEndsWith("<",  case lt 1L)
-        assertEndsWith("<=", case lte 1L)
         assertEndsWith(">",  case gt 1L)
-        assertEndsWith(">=", case gte 1L)
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -26,6 +26,35 @@ class CaseWhenSqlTest {
             captureBoundArgs(frag.parameters, frag.bindArgs),
         )
     }
+
+    @Test
+    fun case_multipleBranches_withElse_emitsExpectedSql() {
+        val case: CaseWhen<TestObject> = TestObject::sealed.case<TestObject, TestSealed> {
+            whenIs<TestSealed.Impl>(TestObject::sealed.then(TestSealed.Impl::boolean))
+            whenIs<TestSealed.Impl2>(TestObject::sealed.then(TestSealed.Impl2::value))
+            elseValue(TestObject::name.builder())
+        }
+
+        val frag = case.toSqlValue()
+
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) " +
+                "WHEN json_extract(entity.value, ?) = ? THEN json_extract(entity.value, ?) " +
+                "ELSE json_extract(entity.value, ?) " +
+                "END)",
+            frag.sql,
+        )
+        assertEquals(7, frag.parameters)
+        assertEquals(
+            listOf(
+                "\$.sealed[0]", "Impl", "\$.sealed[1].boolean",
+                "\$.sealed[0]", "Impl2", "\$.sealed[1]",
+                "\$.name",
+            ),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
 }
 
 /** Replays a bindArgs lambda against a recording prepared statement so tests can assert binds. */

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -59,4 +59,65 @@ class CaseWhereSqlTest {
             captureBoundArgs(q.parameters, q.bindArgs),
         )
     }
+
+    @Test
+    fun caseWhere_withDefault_emitsElseClause() {
+        val w: Where<Order> = Order::class.caseWhere {
+            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+            default { Order::class.with(Order::id) eq "fallback" }
+        }
+
+        val q = w.toSqlQuery(1)
+
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) < ?) " +
+                "ELSE (json_extract(entity.value, ?) = ?) " +
+                "END)",
+            q.where,
+        )
+        assertEquals(6, q.parameters)
+        assertEquals(
+            listOf("\$[0]", "Active", "\$[1].dueAt", 100L, "\$.id", "fallback"),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
+    fun caseWhere_default_calledTwice_throws() {
+        try {
+            Order::class.caseWhere {
+                whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+                default { Order::class.with(Order::id) eq "a" }
+                default { Order::class.with(Order::id) eq "b" }
+            }
+            kotlin.test.fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // ok
+        }
+    }
+
+    @Test
+    fun caseWhere_onlyDefault_isAllowed() {
+        // SQL `CASE ELSE x END` is valid (and useful as an unconditional fallback).
+        val w: Where<Order> = Order::class.caseWhere {
+            default { Order::class.with(Order::id) eq "x" }
+        }
+        val q = w.toSqlQuery(1)
+        assertEquals(
+            "(CASE ELSE (json_extract(entity.value, ?) = ?) END)",
+            q.where,
+        )
+    }
+
+    @Test
+    fun caseWhere_emptyBuilder_throwsAtFirstUse() {
+        val w: Where<Order> = Order::class.caseWhere { /* no branches */ }
+        try {
+            w.toSqlQuery(1)
+            kotlin.test.fail("expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            // ok
+        }
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -124,6 +124,46 @@ class CaseWhereSqlTest {
     }
 
     @Test
+    fun caseWhere_branchWithCompoundAndPredicate() {
+        val w: Where<Order> = Order::class.caseWhere {
+            whenIs<Order.Active> {
+                (with(Order.Active::priority) gt 7).and(with(Order.Active::dueAt) lt 100L)
+            }
+        }
+
+        val q = w.toSqlQuery(1)
+
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? " +
+                "THEN ((json_extract(entity.value, ?) > ?) AND (json_extract(entity.value, ?) < ?)) " +
+                "END)",
+            q.where,
+        )
+        assertEquals(6, q.parameters)
+        assertEquals(
+            listOf("\$[0]", "Active", "\$[1].priority", 7L, "\$[1].dueAt", 100L),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+
+    @Test
+    fun caseWhere_nested_compilesAndLowers() {
+        val w: Where<Order> = Order::class.caseWhere {
+            whenIs<Order.Active> {
+                // nested caseWhere returning Where<Order>
+                Order::class.caseWhere {
+                    whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+                }
+            }
+        }
+
+        val q = w.toSqlQuery(1)
+        // outer CASE, inner CASE — verify the nested CASE appears in the THEN clause
+        assertEquals(true, q.where!!.contains("CASE WHEN json_extract(entity.value, ?) = ? THEN (CASE"))
+    }
+
+    @Test
     fun caseWhere_onProperty_dispatchesByFieldValue() {
         val w: Where<Shipment> = caseWhere(Shipment::status) {
             whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -1,6 +1,8 @@
 package com.mercury.sqkon.db
 
 import com.mercury.sqkon.Order
+import com.mercury.sqkon.Shipment
+import com.mercury.sqkon.ShipmentStatus
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -119,5 +121,33 @@ class CaseWhereSqlTest {
         } catch (e: IllegalArgumentException) {
             // ok
         }
+    }
+
+    @Test
+    fun caseWhere_onProperty_dispatchesByFieldValue() {
+        val w: Where<Shipment> = caseWhere(Shipment::status) {
+            whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }
+            whenEq(ShipmentStatus.RETURNED) { Shipment::returnedAt gt 1000L }
+            default { Shipment::flagged eq true }
+        }
+
+        val q = w.toSqlQuery(1)
+
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) IS NOT NULL) " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) > ?) " +
+                "ELSE (json_extract(entity.value, ?) = ?) " +
+                "END)",
+            q.where,
+        )
+        assertEquals(
+            listOf(
+                "\$.status", "KEPT", "\$.trackerId",
+                "\$.status", "RETURNED", "\$.returnedAt", 1000L,
+                "\$.flagged", true,
+            ),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
     }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -94,8 +94,7 @@ class CaseWhereSqlTest {
                 default { Order::class.with(Order::id) eq "b" }
             }
             kotlin.test.fail("expected IllegalArgumentException")
-        } catch (e: IllegalArgumentException) {
-            // ok
+        } catch (_: IllegalArgumentException) {
         }
     }
 
@@ -114,12 +113,11 @@ class CaseWhereSqlTest {
 
     @Test
     fun caseWhere_emptyBuilder_throwsAtFirstUse() {
-        val w: Where<Order> = Order::class.caseWhere { /* no branches */ }
+        val w: Where<Order> = Order::class.caseWhere { }
         try {
             w.toSqlQuery(1)
             kotlin.test.fail("expected IllegalArgumentException")
-        } catch (e: IllegalArgumentException) {
-            // ok
+        } catch (_: IllegalArgumentException) {
         }
     }
 
@@ -151,7 +149,6 @@ class CaseWhereSqlTest {
     fun caseWhere_nested_compilesAndLowers() {
         val w: Where<Order> = Order::class.caseWhere {
             whenIs<Order.Active> {
-                // nested caseWhere returning Where<Order>
                 Order::class.caseWhere {
                     whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
                 }
@@ -159,7 +156,6 @@ class CaseWhereSqlTest {
         }
 
         val q = w.toSqlQuery(1)
-        // outer CASE, inner CASE — verify the nested CASE appears in the THEN clause
         assertEquals(true, q.where!!.contains("CASE WHEN json_extract(entity.value, ?) = ? THEN (CASE"))
     }
 

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -30,4 +30,33 @@ class CaseWhereSqlTest {
             captureBoundArgs(q.parameters, q.bindArgs),
         )
     }
+
+    @Test
+    fun caseWhere_multipleSealedBranches_emitsExpectedSql() {
+        val w: Where<Order> = Order::class.caseWhere {
+            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+            whenIs<Order.Pending> { with(Order.Pending::reviewedAt) eq null }
+            whenIs<Order.Cancelled> { with(Order.Cancelled::reason) eq "BLOCKED" }
+        }
+
+        val q = w.toSqlQuery(1)
+
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) < ?) " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) IS NULL) " +
+                "WHEN json_extract(entity.value, ?) = ? THEN (json_extract(entity.value, ?) = ?) " +
+                "END)",
+            q.where,
+        )
+        assertEquals(11, q.parameters)
+        assertEquals(
+            listOf(
+                "\$[0]", "Active", "\$[1].dueAt", 100L,
+                "\$[0]", "Pending", "\$[1].reviewedAt",
+                "\$[0]", "Cancelled", "\$[1].reason", "BLOCKED",
+            ),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhereSqlTest.kt
@@ -1,0 +1,33 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.Order
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CaseWhereSqlTest {
+
+    @Test
+    fun caseWhere_singleSealedBranch_emitsExpectedSql() {
+        val w: Where<Order> = Order::class.caseWhere {
+            whenIs<Order.Active> {
+                with(Order.Active::dueAt) lt 100L
+            }
+        }
+
+        val q = w.toSqlQuery(increment = 1)
+
+        assertEquals(null, q.from)
+        assertEquals(
+            "(CASE " +
+                "WHEN json_extract(entity.value, ?) = ? " +
+                "THEN (json_extract(entity.value, ?) < ?) " +
+                "END)",
+            q.where,
+        )
+        assertEquals(4, q.parameters)
+        assertEquals(
+            listOf("\$[0]", "Active", "\$[1].dueAt", 100L),
+            captureBoundArgs(q.parameters, q.bindArgs),
+        )
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
@@ -46,4 +46,23 @@ class KeyValueStorageCaseWhenTest {
 
         assertEquals(listOf("a2", "p2"), ids)
     }
+
+    @Test
+    fun orderBy_caseExpression_ordersAcrossVariantsByLogicalTimestamp() = runTest {
+        storage.insertAll(mapOf(
+            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
+            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 400L),
+            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
+            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 200L),
+        ))
+
+        val ordered = storage.select(
+            orderBy = listOf(OrderBy(timeCase(), OrderDirection.DESC)),
+        ).first()
+
+        val ids = ordered.map {
+            when (it) { is SealedTimed.Active -> it.id; is SealedTimed.Pending -> it.id }
+        }
+        assertEquals(listOf("p1", "a2", "p2", "a1"), ids)
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
@@ -1,0 +1,49 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.SealedTimed
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KeyValueStorageCaseWhenTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<SealedTimed>(
+        "sealed-timed", entityQueries, metadataQueries, mainScope,
+    )
+
+    @AfterTest fun tearDown() { mainScope.cancel() }
+
+    private fun timeCase(): CaseWhen<SealedTimed> = SealedTimed::class.case {
+        whenIs<SealedTimed.Active>(
+            SealedTimed::class.with(SealedTimed.Active::activatedAt)
+        )
+        whenIs<SealedTimed.Pending>(
+            SealedTimed::class.with(SealedTimed.Pending::requestedAt)
+        )
+    }
+
+    @Test
+    fun where_caseGt_filtersAcrossVariants() = runTest {
+        storage.insertAll(mapOf(
+            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
+            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
+            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 200L),
+            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 400L),
+        ))
+
+        val above250 = storage.select(where = timeCase() gt 250L).first()
+        val ids = above250.map {
+            when (it) { is SealedTimed.Active -> it.id; is SealedTimed.Pending -> it.id }
+        }.sorted()
+
+        assertEquals(listOf("a2", "p2"), ids)
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
@@ -21,6 +21,11 @@ class KeyValueStorageCaseWhenTest {
 
     @AfterTest fun tearDown() { mainScope.cancel() }
 
+    /**
+     * The canonical case/when expression for these tests:
+     *   when Active  -> $.activatedAt
+     *   when Pending -> $.requestedAt
+     */
     private fun timeCase(): CaseWhen<SealedTimed> = SealedTimed::class.case {
         whenIs<SealedTimed.Active>(
             SealedTimed::class.with(SealedTimed.Active::activatedAt)
@@ -30,50 +35,78 @@ class KeyValueStorageCaseWhenTest {
         )
     }
 
+    private val SealedTimed.id: String
+        get() = when (this) {
+            is SealedTimed.Active -> id
+            is SealedTimed.Pending -> id
+        }
+
     @Test
-    fun where_caseGt_filtersAcrossVariants() = runTest {
+    fun where_caseEq_picksRightFieldPerVariant() = runTest {
+        // Active rows hold the value in `activatedAt`; Pending rows hold it in `requestedAt`.
+        // `time eq 100L` should match the row in EACH variant whose own field equals 100,
+        // because CASE picks the right path per row's discriminator.
         storage.insertAll(mapOf(
-            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
-            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
-            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 200L),
-            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 400L),
+            "a-100" to SealedTimed.Active(id = "a-100", activatedAt = 100L),  // active match
+            "a-50"  to SealedTimed.Active(id = "a-50",  activatedAt = 50L),
+            "p-100" to SealedTimed.Pending(id = "p-100", requestedAt = 100L), // pending match
+            "p-50"  to SealedTimed.Pending(id = "p-50",  requestedAt = 50L),
+        ))
+        val time = timeCase()
+
+        // CASE eq 100 picks whichever variant's field equals 100.
+        val matches100 = storage.select(where = time eq 100L).first()
+        assertEquals(setOf("a-100", "p-100"), matches100.map { it.id }.toSet())
+
+        // CASE eq 50 picks the other pair.
+        val matches50 = storage.select(where = time eq 50L).first()
+        assertEquals(setOf("a-50", "p-50"), matches50.map { it.id }.toSet())
+    }
+
+    @Test
+    fun where_caseGt_filtersAcrossVariantsByLogicalValue() = runTest {
+        // Pivot at 150: Active rows past activatedAt > 150, Pending rows past requestedAt > 150.
+        storage.insertAll(mapOf(
+            "a-100" to SealedTimed.Active(id = "a-100", activatedAt = 100L),
+            "a-300" to SealedTimed.Active(id = "a-300", activatedAt = 300L), // active > 150
+            "p-200" to SealedTimed.Pending(id = "p-200", requestedAt = 200L), // pending > 150
+            "p-100" to SealedTimed.Pending(id = "p-100", requestedAt = 100L),
         ))
 
-        val above250 = storage.select(where = timeCase() gt 250L).first()
-        val ids = above250.map {
-            when (it) { is SealedTimed.Active -> it.id; is SealedTimed.Pending -> it.id }
-        }.sorted()
+        val above150 = storage.select(where = timeCase() gt 150L).first()
 
-        assertEquals(listOf("a2", "p2"), ids)
+        assertEquals(setOf("a-300", "p-200"), above150.map { it.id }.toSet())
     }
 
     @Test
     fun where_caseGt_combinedWith_jsonTreeEq_viaAnd() = runTest {
+        // Two SQL patterns coexist in one query:
+        //   - timeCase() gt 150L  (CASE/json_extract scalar)
+        //   - SealedTimed.Active::id eq "a-300"  (json_tree LATERAL join)
         storage.insertAll(mapOf(
-            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
-            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
-            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 250L),
-            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 400L),
+            "a-100" to SealedTimed.Active(id = "a-100", activatedAt = 100L),
+            "a-300" to SealedTimed.Active(id = "a-300", activatedAt = 300L),
+            "p-200" to SealedTimed.Pending(id = "p-200", requestedAt = 200L),
+            "p-300" to SealedTimed.Pending(id = "p-300", requestedAt = 300L),
         ))
 
-        val activeAndAbove150 = storage.select(
+        val activeAbove150WithSpecificId = storage.select(
             where = (timeCase() gt 150L) and (
-                SealedTimed::class.with(SealedTimed.Active::id) eq "a2"
+                SealedTimed::class.with(SealedTimed.Active::id) eq "a-300"
             ),
         ).first()
 
-        assertEquals(1, activeAndAbove150.size)
-        assertEquals("a2", (activeAndAbove150.single() as SealedTimed.Active).id)
+        assertEquals(1, activeAbove150WithSpecificId.size)
+        assertEquals("a-300", (activeAbove150WithSpecificId.single() as SealedTimed.Active).id)
     }
 
     @Test
     fun where_caseIsNull_matchesRowsWithNoMatchingBranch() = runTest {
         storage.insertAll(mapOf(
-            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
-            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 200L),
+            "a-100" to SealedTimed.Active(id = "a-100", activatedAt = 100L),
+            "p-200" to SealedTimed.Pending(id = "p-200", requestedAt = 200L),
         ))
-
-        // CaseWhen with only an Active branch -> Pending rows fall through to NULL
+        // CASE with only an Active branch -> Pending rows fall through to NULL.
         val activeOnly: CaseWhen<SealedTimed> = SealedTimed::class.case {
             whenIs<SealedTimed.Active>(
                 SealedTimed::class.with(SealedTimed.Active::activatedAt)
@@ -81,30 +114,27 @@ class KeyValueStorageCaseWhenTest {
         }
 
         val nulls = storage.select(where = activeOnly.isNull()).first()
-        assertEquals(1, nulls.size)
-        assertEquals("p1", (nulls.single() as SealedTimed.Pending).id)
+        assertEquals(listOf("p-200"), nulls.map { it.id })
 
         val nonNulls = storage.select(where = activeOnly.isNotNull()).first()
-        assertEquals(1, nonNulls.size)
-        assertEquals("a1", (nonNulls.single() as SealedTimed.Active).id)
+        assertEquals(listOf("a-100"), nonNulls.map { it.id })
     }
 
     @Test
     fun orderBy_caseExpression_ordersAcrossVariantsByLogicalTimestamp() = runTest {
+        // Each row's id encodes its logical value so the expected order is obvious.
         storage.insertAll(mapOf(
-            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
-            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 400L),
-            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
-            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 200L),
+            "a-100" to SealedTimed.Active(id = "a-100", activatedAt = 100L),
+            "p-400" to SealedTimed.Pending(id = "p-400", requestedAt = 400L),
+            "a-300" to SealedTimed.Active(id = "a-300", activatedAt = 300L),
+            "p-200" to SealedTimed.Pending(id = "p-200", requestedAt = 200L),
         ))
 
         val ordered = storage.select(
             orderBy = listOf(OrderBy(timeCase(), OrderDirection.DESC)),
         ).first()
 
-        val ids = ordered.map {
-            when (it) { is SealedTimed.Active -> it.id; is SealedTimed.Pending -> it.id }
-        }
-        assertEquals(listOf("p1", "a2", "p2", "a1"), ids)
+        // Sorted by per-variant value DESC: 400, 300, 200, 100.
+        assertEquals(listOf("p-400", "a-300", "p-200", "a-100"), ordered.map { it.id })
     }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
@@ -67,6 +67,29 @@ class KeyValueStorageCaseWhenTest {
     }
 
     @Test
+    fun where_caseIsNull_matchesRowsWithNoMatchingBranch() = runTest {
+        storage.insertAll(mapOf(
+            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
+            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 200L),
+        ))
+
+        // CaseWhen with only an Active branch -> Pending rows fall through to NULL
+        val activeOnly: CaseWhen<SealedTimed> = SealedTimed::class.case {
+            whenIs<SealedTimed.Active>(
+                SealedTimed::class.with(SealedTimed.Active::activatedAt)
+            )
+        }
+
+        val nulls = storage.select(where = activeOnly.isNull()).first()
+        assertEquals(1, nulls.size)
+        assertEquals("p1", (nulls.single() as SealedTimed.Pending).id)
+
+        val nonNulls = storage.select(where = activeOnly.isNotNull()).first()
+        assertEquals(1, nonNulls.size)
+        assertEquals("a1", (nonNulls.single() as SealedTimed.Active).id)
+    }
+
+    @Test
     fun orderBy_caseExpression_ordersAcrossVariantsByLogicalTimestamp() = runTest {
         storage.insertAll(mapOf(
             "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhenTest.kt
@@ -48,6 +48,25 @@ class KeyValueStorageCaseWhenTest {
     }
 
     @Test
+    fun where_caseGt_combinedWith_jsonTreeEq_viaAnd() = runTest {
+        storage.insertAll(mapOf(
+            "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),
+            "a2" to SealedTimed.Active(id = "a2", activatedAt = 300L),
+            "p1" to SealedTimed.Pending(id = "p1", requestedAt = 250L),
+            "p2" to SealedTimed.Pending(id = "p2", requestedAt = 400L),
+        ))
+
+        val activeAndAbove150 = storage.select(
+            where = (timeCase() gt 150L) and (
+                SealedTimed::class.with(SealedTimed.Active::id) eq "a2"
+            ),
+        ).first()
+
+        assertEquals(1, activeAndAbove150.size)
+        assertEquals("a2", (activeAndAbove150.single() as SealedTimed.Active).id)
+    }
+
+    @Test
     fun orderBy_caseExpression_ordersAcrossVariantsByLogicalTimestamp() = runTest {
         storage.insertAll(mapOf(
             "a1" to SealedTimed.Active(id = "a1", activatedAt = 100L),

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhereTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhereTest.kt
@@ -144,8 +144,8 @@ class KeyValueStorageCaseWhereTest {
         ))
 
         val w = Order::class.caseWhere {
-            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L } // matches a
-            default { Order::class.with(Order.Cancelled::id) eq "c" } // matches c
+            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+            default { Order::class.with(Order.Cancelled::id) eq "c" }
         }
         val matched = orders.select(where = w).first()
 
@@ -161,7 +161,6 @@ class KeyValueStorageCaseWhereTest {
 
         val w = Order::class.caseWhere {
             whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
-            // no Pending branch, no default
         }
         val matched = orders.select(where = w).first()
 

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhereTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCaseWhereTest.kt
@@ -1,0 +1,177 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.Order
+import com.mercury.sqkon.Shipment
+import com.mercury.sqkon.ShipmentStatus
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KeyValueStorageCaseWhereTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val orders = keyValueStorage<Order>(
+        "orders", entityQueries, metadataQueries, mainScope,
+    )
+    private val shipments = keyValueStorage<Shipment>(
+        "shipments", entityQueries, metadataQueries, mainScope,
+    )
+
+    @AfterTest fun tearDown() { mainScope.cancel() }
+
+    /** Example 1: trivial single sealed branch — Pending/Cancelled excluded. */
+    @Test fun example1_singleBranch_excludesOtherVariants() = runTest {
+        orders.insertAll(mapOf(
+            "a" to Order.Active(id = "a", dueAt = 100L, priority = 5),
+            "p" to Order.Pending(id = "p", reviewedAt = null),
+        ))
+
+        val urgentActive = orders.select(where = Order::class.caseWhere {
+            whenIs<Order.Active> { with(Order.Active::priority) gt 3 }
+        }).first()
+
+        assertEquals(listOf("a"), urgentActive.map { it.id })
+    }
+
+    /** Example 2: different fields, operators, RHS types per variant. */
+    @Test fun example2_perVariantFieldsAndOps() = runTest {
+        orders.insertAll(mapOf(
+            "a-due"     to Order.Active(id = "a-due", dueAt = 50L, priority = 1),
+            "a-ok"      to Order.Active(id = "a-ok",  dueAt = 200L, priority = 1),
+            "p-stale"   to Order.Pending(id = "p-stale", reviewedAt = null),
+            "p-fresh"   to Order.Pending(id = "p-fresh", reviewedAt = 99L),
+            "c-blocked" to Order.Cancelled(id = "c-blocked", reason = "BLOCKED"),
+            "c-other"   to Order.Cancelled(id = "c-other",   reason = "DUPLICATE"),
+        ))
+
+        val needsAttention = orders.select(where = Order::class.caseWhere {
+            whenIs<Order.Active>    { with(Order.Active::dueAt) lt 100L }
+            whenIs<Order.Pending>   { with(Order.Pending::reviewedAt) eq null }
+            whenIs<Order.Cancelled> { with(Order.Cancelled::reason) eq "BLOCKED" }
+        }).first()
+
+        assertEquals(setOf("a-due", "p-stale", "c-blocked"), needsAttention.map { it.id }.toSet())
+    }
+
+    /** Example 3: discriminator-field dispatch (non-sealed). */
+    @Test fun example3_discriminatorFieldDispatch() = runTest {
+        shipments.insertAll(mapOf(
+            "k1" to Shipment(id = "k1", status = ShipmentStatus.KEPT,       trackerId = "T1"),
+            "k2" to Shipment(id = "k2", status = ShipmentStatus.KEPT,       trackerId = null),
+            "r1" to Shipment(id = "r1", status = ShipmentStatus.RETURNED,   returnedAt = 5000L),
+            "r2" to Shipment(id = "r2", status = ShipmentStatus.RETURNED,   returnedAt = 100L),
+            "i1" to Shipment(id = "i1", status = ShipmentStatus.IN_TRANSIT),
+        ))
+
+        val visible = shipments.select(where = caseWhere(Shipment::status) {
+            whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }
+            whenEq(ShipmentStatus.RETURNED) { Shipment::returnedAt gt 1000L }
+        }).first()
+
+        assertEquals(setOf("k1", "r1"), visible.map { it.id }.toSet())
+    }
+
+    /** Example 4: composes with regular and/or under the outer where. */
+    @Test fun example4_composesWithOuterAndOr() = runTest {
+        orders.insertAll(mapOf(
+            "a-mine"  to Order.Active(id = "a-mine",  dueAt = 10L, priority = 1),
+            "a-other" to Order.Active(id = "a-other", dueAt = 10L, priority = 1),
+            "p-mine"  to Order.Pending(id = "p-mine", reviewedAt = null),
+        ))
+
+        val needsAttentionMine = orders.select(where =
+            Order::class.caseWhere {
+                whenIs<Order.Active>  { with(Order.Active::dueAt) lt 100L }
+                whenIs<Order.Pending> { with(Order.Pending::reviewedAt) eq null }
+            }.and(Order::class.with(Order.Active::id) like "%-mine"),
+        ).first()
+
+        assertEquals(setOf("a-mine", "p-mine"), needsAttentionMine.map { it.id }.toSet())
+    }
+
+    /** Example 5: compound predicate within a single branch. */
+    @Test fun example5_compoundBranchPredicate() = runTest {
+        orders.insertAll(mapOf(
+            "a-hi-due" to Order.Active(id = "a-hi-due", dueAt = 10L,  priority = 9),
+            "a-hi-ok"  to Order.Active(id = "a-hi-ok",  dueAt = 999L, priority = 9),
+            "a-lo-due" to Order.Active(id = "a-lo-due", dueAt = 10L,  priority = 1),
+        ))
+
+        val highAndDue = orders.select(where = Order::class.caseWhere {
+            whenIs<Order.Active> {
+                (with(Order.Active::priority) gt 5)
+                    .and(with(Order.Active::dueAt) lt 100L)
+            }
+        }).first()
+
+        assertEquals(listOf("a-hi-due"), highAndDue.map { it.id })
+    }
+
+    /** Example 6 (stretch): nested caseWhere inside a branch. */
+    @Test fun example6_nestedCaseWhere() = runTest {
+        orders.insertAll(mapOf(
+            "a-hi" to Order.Active(id = "a-hi", dueAt = 10L, priority = 9),
+            "a-lo" to Order.Active(id = "a-lo", dueAt = 10L, priority = 1),
+            "p"    to Order.Pending(id = "p", reviewedAt = null),
+        ))
+
+        val w = Order::class.caseWhere {
+            whenIs<Order.Active> {
+                Order::class.caseWhere {
+                    whenIs<Order.Active> { with(Order.Active::priority) gt 5 }
+                }
+            }
+            whenIs<Order.Pending> { with(Order.Pending::reviewedAt) eq null }
+        }
+        val matched = orders.select(where = w).first()
+
+        assertEquals(setOf("a-hi", "p"), matched.map { it.id }.toSet())
+    }
+
+    /** Default branch falls back when no variant matches. */
+    @Test fun default_fallsBackForUnmatchedVariants() = runTest {
+        orders.insertAll(mapOf(
+            "a" to Order.Active(id = "a", dueAt = 10L, priority = 1),
+            "p" to Order.Pending(id = "p", reviewedAt = null),
+            "c" to Order.Cancelled(id = "c", reason = "BLOCKED"),
+        ))
+
+        val w = Order::class.caseWhere {
+            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L } // matches a
+            default { Order::class.with(Order.Cancelled::id) eq "c" } // matches c
+        }
+        val matched = orders.select(where = w).first()
+
+        assertEquals(setOf("a", "c"), matched.map { it.id }.toSet())
+    }
+
+    /** No default and no matching branch -> row falls through to NULL/falsy. */
+    @Test fun noDefault_unmatchedVariantsExcluded() = runTest {
+        orders.insertAll(mapOf(
+            "a" to Order.Active(id = "a", dueAt = 10L, priority = 1),
+            "p" to Order.Pending(id = "p", reviewedAt = null),
+        ))
+
+        val w = Order::class.caseWhere {
+            whenIs<Order.Active> { with(Order.Active::dueAt) lt 100L }
+            // no Pending branch, no default
+        }
+        val matched = orders.select(where = w).first()
+
+        assertEquals(listOf("a"), matched.map { it.id })
+    }
+
+    private val Order.id: String
+        get() = when (this) {
+            is Order.Active    -> id
+            is Order.Pending   -> id
+            is Order.Cancelled -> id
+        }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
@@ -284,6 +284,34 @@ class KeyValueStorageTest {
     }
 
     @Test
+    fun select_byNullableField_eqNull_returnsRowsWithNull() = runTest {
+        val withNull = TestObject(nullable = null)
+        val withValue = TestObject(nullable = "present")
+        testObjectStorage.insertAll(mapOf(withNull.id to withNull, withValue.id to withValue))
+
+        val actual = testObjectStorage.select(
+            where = TestObject::nullable eq null
+        ).first()
+
+        assertEquals(1, actual.size)
+        assertEquals(withNull, actual.first())
+    }
+
+    @Test
+    fun select_byNullableField_neqNull_returnsRowsWithValue() = runTest {
+        val withNull = TestObject(nullable = null)
+        val withValue = TestObject(nullable = "present")
+        testObjectStorage.insertAll(mapOf(withNull.id to withNull, withValue.id to withValue))
+
+        val actual = testObjectStorage.select(
+            where = TestObject::nullable neq null
+        ).first()
+
+        assertEquals(1, actual.size)
+        assertEquals(withValue, actual.first())
+    }
+
+    @Test
     fun select_byEntityAttributeList() = runTest {
         val expected = (1..10).map { num ->
             TestObject(attributes = listOf("${num}1", "${num}2"))

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
@@ -31,4 +31,35 @@ class ScalarLoweringTest {
             captureBoundArgs(frag.parameters, frag.bindArgs),
         )
     }
+
+    @Test
+    fun gt_scalarForm() {
+        val w: Where<TestObject> = TestObject::value gt 100L
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) > ?)", frag.sql)
+        assertEquals(listOf("\$.value", 100L), captureBoundArgs(frag.parameters, frag.bindArgs))
+    }
+
+    @Test
+    fun lt_scalarForm() {
+        val w: Where<TestObject> = TestObject::value lt 100L
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) < ?)", frag.sql)
+    }
+
+    @Test
+    fun eqNull_scalarForm_emitsIsNull() {
+        val w: Where<TestObject> = TestObject::name eq null
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) IS NULL)", frag.sql)
+        assertEquals(1, frag.parameters)
+        assertEquals(listOf("\$.name"), captureBoundArgs(frag.parameters, frag.bindArgs))
+    }
+
+    @Test
+    fun neqNull_scalarForm_emitsIsNotNull() {
+        val w: Where<TestObject> = TestObject::name neq null
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) IS NOT NULL)", frag.sql)
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
@@ -97,4 +97,40 @@ class ScalarLoweringTest {
             frag.sql,
         )
     }
+
+    @Test
+    fun like_scalarForm() {
+        val w: Where<TestObject> = TestObject::name like "Star%"
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) LIKE ?)", frag.sql)
+        assertEquals(listOf("\$.name", "Star%"), captureBoundArgs(frag.parameters, frag.bindArgs))
+    }
+
+    @Test
+    fun inList_scalarForm() {
+        val w: Where<TestObject> = TestObject::name inList listOf("A", "B", "C")
+        val frag = w.toScalarSqlValue()
+        assertEquals("(json_extract(entity.value, ?) IN (?, ?, ?))", frag.sql)
+        assertEquals(4, frag.parameters)
+        assertEquals(
+            listOf("\$.name", "A", "B", "C"),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+
+    @Test
+    fun inList_emptyList_scalarForm_isAlwaysFalse() {
+        val w: Where<TestObject> = TestObject::name inList emptyList<String>()
+        val frag = w.toScalarSqlValue()
+        assertEquals("(0)", frag.sql)
+        assertEquals(0, frag.parameters)
+    }
+
+    @Test
+    fun notInList_emptyList_scalarForm_isAlwaysTrue() {
+        val w: Where<TestObject> = TestObject::name.notInList(emptyList<String>())
+        val frag = w.toScalarSqlValue()
+        assertEquals("(1)", frag.sql)
+        assertEquals(0, frag.parameters)
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
@@ -1,0 +1,34 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ScalarLoweringTest {
+
+    @Test
+    fun eq_scalarForm_emitsJsonExtract() {
+        val w: Where<TestObject> = TestObject::name eq "Coffee"
+        val frag = w.toScalarSqlValue()
+
+        assertEquals("(json_extract(entity.value, ?) = ?)", frag.sql)
+        assertEquals(2, frag.parameters)
+        assertEquals(
+            listOf("\$.name", "Coffee"),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+
+    @Test
+    fun neq_scalarForm_emitsJsonExtract() {
+        val w: Where<TestObject> = TestObject::name neq "Hidden"
+        val frag = w.toScalarSqlValue()
+
+        assertEquals("(json_extract(entity.value, ?) != ?)", frag.sql)
+        assertEquals(2, frag.parameters)
+        assertEquals(
+            listOf("\$.name", "Hidden"),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/ScalarLoweringTest.kt
@@ -62,4 +62,39 @@ class ScalarLoweringTest {
         val frag = w.toScalarSqlValue()
         assertEquals("(json_extract(entity.value, ?) IS NOT NULL)", frag.sql)
     }
+
+    @Test
+    fun and_scalarForm_concatsChildren() {
+        val w = (TestObject::name eq "Coffee").and(TestObject::value gt 100L)
+        val frag = w.toScalarSqlValue()
+        assertEquals(
+            "((json_extract(entity.value, ?) = ?) AND (json_extract(entity.value, ?) > ?))",
+            frag.sql,
+        )
+        assertEquals(4, frag.parameters)
+        assertEquals(
+            listOf("\$.name", "Coffee", "\$.value", 100L),
+            captureBoundArgs(frag.parameters, frag.bindArgs),
+        )
+    }
+
+    @Test
+    fun or_scalarForm_concatsChildrenWithOr() {
+        val w = (TestObject::name eq "A").or(TestObject::name eq "B")
+        val frag = w.toScalarSqlValue()
+        assertEquals(
+            "((json_extract(entity.value, ?) = ?) OR (json_extract(entity.value, ?) = ?))",
+            frag.sql,
+        )
+    }
+
+    @Test
+    fun not_scalarForm_wrapsChild() {
+        val w = not(TestObject::name eq "Hidden")
+        val frag = w.toScalarSqlValue()
+        assertEquals(
+            "(NOT (json_extract(entity.value, ?) = ?))",
+            frag.sql,
+        )
+    }
 }


### PR DESCRIPTION
Closes [MOB-1627](https://linear.app/mercury/issue/MOB-1627) / [#6](https://github.com/MercuryTechnologies/sqkon/issues/6).

## Summary

Adds two complementary CASE/WHEN expressions to the query DSL for sealed-variant queries:

1. **`case { whenIs<V>(path) }`** — value-selection. Picks a JSON path per variant; produces a `CaseWhen<T>` you compare against a single RHS (`eq`/`gt`/`lt`/…) or feed to `ORDER BY`.
2. **`caseWhere { whenIs<V> { pred } }`** — predicate-dispatch. Picks a whole predicate per variant; produces a `Where<T>` for filtering with different operators/RHS types per variant. WHERE-only.

The existing `Eq`/`Gt`/… operators all compile to a lateral `json_tree(entity.value, '$') AS alias` join — that pattern can't pick a path conditionally on the row's discriminator. Both new forms compile to scalar `(CASE WHEN json_extract(entity.value, ?) = ? THEN … END)` instead. Branch predicates inside `caseWhere` lower via a new internal `Where<T>.toScalarSqlValue()` method (parallel to the existing `json_tree`-based `toSqlQuery`) so any `Where<T>` composes inside a CASE.

### `case` — value selection

```kotlin
val effectiveTime = Status::class.case {
    whenIs<Status.Active>(Status::class.with(Status.Active::activatedAt))
    whenIs<Status.Pending>(Status::class.with(Status.Pending::requestedAt))
}
storage.select(where = effectiveTime gt 1_700_000_000L)
storage.select(orderBy = listOf(OrderBy(effectiveTime, OrderDirection.DESC)))
```

Operators on `CaseWhen<T>`: `eq`, `neq`, `gt`, `lt`, plus `isNull()` / `isNotNull()`.

### `caseWhere` — predicate dispatch

```kotlin
orders.select(where = Order::class.caseWhere {
    whenIs<Order.Active>    { with(Order.Active::dueAt) lt cutoff }
    whenIs<Order.Pending>   { with(Order.Pending::reviewedAt) eq null }
    whenIs<Order.Cancelled> { with(Order.Cancelled::reason) eq "BLOCKED" }
})
```

Inside each `whenIs<V>` block, `with(KProperty1<V, X>)` is **scoped to the variant** — `with(Pending::reviewedAt)` won't compile inside a `whenIs<Active> { ... }` block.

Non-sealed (discriminator-field) dispatch via `KProperty1`:

```kotlin
shipments.select(where = caseWhere(Shipment::status) {
    whenEq(ShipmentStatus.KEPT)     { Shipment::trackerId neq null }
    whenEq(ShipmentStatus.RETURNED) { Shipment::returnedAt gt cutoff }
    default { Shipment::flagged eq true }
})
```

`default { ... }` is optional (SQL `ELSE`). Without it, unmatched variants fall through to NULL → falsy in WHERE → excluded. Branch predicates accept the full DSL: `and`/`or`/`not`, nested `caseWhere`, all compose.

## Breaking change

`OrderBy<T>` changed from a `data class` to a `sealed class` with `JsonPathOrderBy<T>` and `CaseOrderBy<T>` subclasses. Every existing call site (`OrderBy(KProperty1, …)`, `OrderBy(JsonPathBuilder, …)`) is preserved via factory functions, but the previously-public `path: String` getter and data-class members (`copy`, `componentN`) are no longer on the parent type. Migrate to the subclass if you used those. Release-please will pick this up as a major bump via the `feat!` prefix and `BREAKING CHANGE:` footer on the OrderBy commit.

## Test plan

- [x] `./gradlew jvmTest` — all tests pass
- [x] `./gradlew verifySqlDelightMigration` — clean, no schema changes
- [x] `CaseWhenSqlTest` (8 cases) — single-branch, multi-branch + ELSE, root-sealed via `KClass.case`, all comparison operators, `isNull`/`isNotNull`, `OrderBy(case, …)` SQL output, JsonPath OrderBy still emits `json_tree` after refactor
- [x] `KeyValueStorageCaseWhenTest` (4 cases against in-memory SQLite) — WHERE filters across variants, ORDER BY orders across variants, `case` composes with `json_tree` predicate via `and`, NULL fall-through selectable via `isNull()`/`isNotNull()`
- [x] `ScalarLoweringTest` (13 cases) — every `Where<T>` operator's scalar form (`Eq`/`NotEq`/`Gt`/`Lt`/`Like`/`In`/`NotIn`/`And`/`Or`/`Not` + null-aware `Eq`/`NotEq`)
- [x] `CaseWhereSqlTest` (9 cases) — single-branch, multi-branch, default ELSE, only-default, empty rejected, discriminator-field dispatch, compound branch predicate, nested `caseWhere`, duplicate `default` throws
- [x] `KeyValueStorageCaseWhereTest` (8 cases) — covers the 6 worked examples (single branch, per-variant fields/ops/RHS, non-sealed enum dispatch, compose with outer `and`/`or`, compound branch, nested case) plus default fallback and no-default falsy semantics

## Notes for reviewers

- Discriminator path derived as `<parentPath>[0]` for `case` (sealed payloads sit under `[1]` with `useArrayPolymorphism = true`); `caseWhere` uses the same `$[0]` for sealed entities and `prop.builder().buildPath()` for discriminator-field dispatch.
- `caseWhere` branches use `json_extract` (scalar) rather than `json_tree` LATERAL joins because LATERAL joins multiply rows across variants, breaking per-row dispatch. Every `Where<T>` operator gained an internal `toScalarSqlValue()` companion to enable this.
- `gte`/`lte` intentionally omitted from `CaseWhen` to stay symmetric with `JsonPathBuilder` (which only has `gt`/`lt` today). Follow-up can add both surfaces together.
- `caseWhere` is WHERE-only — predicate dispatch has no ordering. Use `case` for ORDER BY.
- Documentation: README "Sealed (Subclass) Classes" section covers both. `docs/guides/querying.md` has dedicated sections "CASE / WHEN: per-variant path selection" and "CASE / WHEN: per-variant predicate selection". Cross-links from `docs/guides/serialization-tips.md` and `docs/guides/ordering.md`.