### PR TITLE
docs: polish home page, restructure Querying, fix mermaid, link Why Sqkon cards

### DIFF
--- a/docs/_includes/title.html
+++ b/docs/_includes/title.html
@@ -1,0 +1,5 @@
+{%- comment -%} Override JTD default to render logo + title side-by-side; JTD wraps this partial in <a class="site-title">. {%- endcomment -%}
+{%- if site.logo -%}
+  <img src="{{ site.logo | relative_url }}" alt="" class="site-logo" width="96" height="24" />
+{%- endif -%}
+<span class="site-title-text">{{ site.title }}</span>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -54,6 +54,24 @@ h1, h2, h3, h4 {
   border: 1px solid $mercury-border-soft;
 }
 
+.site-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-logo {
+  display: inline-block;
+  height: 24px;
+  width: auto;
+}
+
+.site-title-text {
+  font-weight: 600;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+
 // Feature grid
 .feature-grid {
   display: grid;
@@ -63,10 +81,26 @@ h1, h2, h3, h4 {
 }
 
 .feature-card {
+  display: block;
   background: $mercury-bg;
   border: 1px solid $mercury-border-soft;
   border-radius: 12px;
   padding: 1.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+
+  &:hover {
+    text-decoration: none;
+    color: inherit;
+    border-color: $mercury-accent;
+    box-shadow: 0 4px 16px rgba($mercury-accent, 0.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $mercury-accent;
+    outline-offset: 2px;
+  }
 }
 
 .feature-card h3 {

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -109,11 +109,9 @@ The single table that holds every value you store. Composite primary key is
 | `write_at`    | INTEGER | UTC epoch millis of last write.                |
 | `read_at`     | INTEGER | UTC epoch millis of last observed read.        |
 
-Indexes:
-
-- `idx_entity_read_at` on `read_at`
-- `idx_entity_write_at` on `write_at`
-- `idx_entity_expires_at` on `expires_at`
+Indexes ship for `read_at`, `write_at`, and `expires_at` — see
+[Performance: built-in indexes]({{ '/guides/performance/#built-in-indexes' | relative_url }})
+for the full table and what each one speeds up.
 
 ### `metadata`
 

--- a/docs/concepts/comparison.md
+++ b/docs/concepts/comparison.md
@@ -13,7 +13,7 @@ out which one fits the problem in front of you.
 
 ## At a glance
 
-| Capability             | Sqkon                  | Room                  | DataStore (Proto)         | Realm                  | MMKV                  | SQLDelight (raw)       |
+| Capability             | Sqkon                  | Room                  | DataStore (Proto)[^ds]    | Realm[^realm]          | MMKV                  | SQLDelight (raw)       |
 |------------------------|------------------------|-----------------------|---------------------------|------------------------|-----------------------|------------------------|
 | KMP support            | Android, JVM           | Android only          | Android only              | KMP (Android, iOS)     | Android, iOS          | KMP (broad)            |
 | Typed objects          | Yes (`@Serializable`)  | Yes (entity classes)  | Yes (Proto schema)        | Yes (`RealmObject`)    | No (primitives + Parcelable) | Yes (codegen)   |
@@ -22,6 +22,9 @@ out which one fits the problem in front of you.
 | Schema migrations      | None per-type          | Required per change   | Proto-evolution rules     | Required per change    | None                  | Required per change    |
 | Encryption             | BYO (e.g. SQLCipher)   | BYO (e.g. SQLCipher)  | BYO                       | Built-in               | Built-in (optional)   | BYO                    |
 | Setup complexity       | Low                    | Medium                | Medium                    | Medium                 | Very low              | Medium-high            |
+
+[^ds]: A `androidx.datastore` Multiplatform port is in active development upstream; production guidance for Android today remains the Preferences and Proto pair.
+[^realm]: The Realm Kotlin SDK is now distributed as the **MongoDB Atlas Device SDK for Kotlin** (same library, renamed). Search for either name.
 
 ## When Sqkon wins
 

--- a/docs/guides/flow.md
+++ b/docs/guides/flow.md
@@ -42,7 +42,7 @@ new result.
 ```mermaid
 sequenceDiagram
     participant Writer
-    participant SqkonStore as KeyValueStorage&lt;T&gt;
+    participant SqkonStore as KeyValueStorage(T)
     participant SQLDelight
     participant Reader as Flow consumer
     Writer->>SqkonStore: insert(...)

--- a/docs/guides/nested-fields.md
+++ b/docs/guides/nested-fields.md
@@ -78,6 +78,17 @@ merchants.select(
 That builds `$.tags[%].name`, which JSONB evaluates as "any element of `tags`
 whose `name` is `'vegan'`".
 
+Every operator works against a list-element path, not just `eq`. For example,
+`inList` over the same shape:
+
+```kotlin
+merchants.select(
+    where = Merchant::tags.then(Tag::name) inList listOf("vegan", "halal"),
+).first()
+```
+
+Matches any merchant where **any** tag's name appears in the supplied list.
+
 > The same `.then(...)` symbol covers nested-object hops AND list-element hops.
 > The compiler picks the overload by inspecting the property's type
 > (`KProperty1<R, Foo>` vs. `KProperty1<R, Collection<Foo>>`). At the JVM level

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -17,6 +17,8 @@ references into `json_tree` predicates, binds the values, and lets SQLite plan
 the query. There is no string-based query API — if it doesn't compile, it
 won't run.
 
+## Quick example
+
 ```kotlin
 @Serializable
 data class Merchant(
@@ -35,41 +37,90 @@ merchants.select(
 ```
 
 Every `select` / `selectAll` returns a `Flow<List<T>>` — the query re-emits
-when the rows it depends on change. See the [Flow guide]({{ '/guides/flow/' | relative_url }})
-for change-propagation details.
+when the rows it depends on change. See the
+[Flow guide]({{ '/guides/flow/' | relative_url }}) for change-propagation
+details.
 
-## How a query gets to SQL
+## Operators at a glance
 
-```mermaid
-flowchart LR
-    DSL["Merchant::name eq 'X'"] --> Where["Where&lt;Merchant&gt;"]
-    Where --> SQL["json_tree join: fullkey LIKE '$.name' AND value = 'X'"]
-    SQL --> Plan["SQLite query plan"]
-```
+The complete operator surface as of the current release. Click an operator to
+jump to its section.
 
-A `Where<T>` is a typed AST node. When the store runs a query, every node is
-asked to emit a `SqlQuery` — a `FROM` (a `json_tree(entity.value, '$')` join),
-a `WHERE` predicate, and the bound parameters. AND/OR combine two child
-queries into one. The store also adds the `entity_name = ?` filter for the
-store you opened, so two stores in the same database never collide.
-
-## Operator reference
+| Operator                                    | What it tests                       |
+|---------------------------------------------|-------------------------------------|
+| [`eq`](#equality-eq-neq) / [`neq`](#equality-eq-neq) | exact match (also `null`)  |
+| [`like`](#string-matching-like)             | SQL `LIKE` pattern                  |
+| [`gt`](#numeric-comparison-gt-lt) / [`lt`](#numeric-comparison-gt-lt) | strict greater/less |
+| [`inList`](#set-membership-inlist-notinlist) / [`notInList`](#set-membership-inlist-notinlist) | value present in / absent from a list |
+| [`and`](#boolean-composition-and-or-not) / [`or`](#boolean-composition-and-or-not) / [`not`](#boolean-composition-and-or-not) | combine other Wheres |
 
 All operators are available as **infix functions on a `KProperty1`** (the
-common case — `Merchant::name`) or on a `JsonPathBuilder` (for nested fields,
-see [Nested fields]({{ '/guides/nested-fields/' | relative_url }})).
+common case — `Merchant::name`) or on a `JsonPathBuilder` for nested fields
+(see [Nested fields]({{ '/guides/nested-fields/' | relative_url }})).
 
-| Operator     | Infix usage                                              | SQL emitted (approx)                                    |
-|--------------|----------------------------------------------------------|---------------------------------------------------------|
-| `eq`         | `Merchant::name eq "Chipotle"`                           | `... fullkey LIKE '$.name' AND value = ?`               |
-| `neq`        | `Merchant::name neq "Chipotle"`                          | `... fullkey LIKE '$.name' AND value != ?`              |
-| `inList`     | `Merchant::category inList listOf("Food", "Coffee")`     | `... fullkey LIKE '$.category' AND value IN (?, ?)`     |
-| `notInList`  | `Merchant::category.notInList(listOf("Food", "Coffee"))` | `... fullkey LIKE '$.category' AND value NOT IN (?, ?)` |
-| `like`       | `Merchant::name like "Chi%"`                             | `... fullkey LIKE '$.name' AND value LIKE ?`            |
-| `gt`         | `Merchant::score gt 100`                                 | `... fullkey LIKE '$.score' AND value > ?`              |
-| `lt`         | `Merchant::score lt 100`                                 | `... fullkey LIKE '$.score' AND value < ?`              |
+## Equality (`eq`, `neq`)
 
-That is the full operator surface as of the current release.
+The simplest predicate: bind a property to a value.
+
+```kotlin
+merchants.select(
+    where = Merchant::name eq "Chipotle",
+).first()
+```
+
+`neq` is the inverse:
+
+```kotlin
+merchants.select(
+    where = Merchant::category neq "Hidden",
+).first()
+```
+
+### Comparing against `null`
+
+`eq` and `neq` accept a nullable value, so null comparison works as you'd
+expect:
+
+```kotlin
+val withoutDescription = merchants.select(
+    where = Merchant::description eq null,
+).first()
+```
+
+`gt` / `lt` against `null` is a runtime error in SQLite — don't do it.
+
+## String matching (`like`)
+
+`like` accepts standard SQLite patterns — `%` for any sequence of characters,
+`_` for a single character.
+
+```kotlin
+val starsomething = merchants.select(
+    where = Merchant::name like "Star%",
+).first()
+```
+
+Bound as a string, so escape your input if it comes from users.
+
+{: .note }
+> **Leading wildcards are slow.** `name like '%foo%'` always scans every row
+> in the store. Trailing wildcards (`'foo%'`) are cheaper because string
+> comparison can short-circuit. See
+> [Performance: query planning]({{ '/guides/performance/#query-planning-for-json-paths' | relative_url }}).
+
+## Numeric comparison (`gt`, `lt`)
+
+Strict-inequality operators on a numeric path.
+
+```kotlin
+val highScoring = merchants.select(
+    where = Merchant::score gt 100,
+).first()
+
+val lowScoring = merchants.select(
+    where = Merchant::score lt 50,
+).first()
+```
 
 {: .note }
 > **No `gte`, `lte`, or `between` (yet).** Compose them yourself:
@@ -77,7 +128,15 @@ That is the full operator surface as of the current release.
 > `(Merchant::score gt 99).and(Merchant::score lt 201)` for an exclusive
 > 100..200 range. If you'd use these often, an issue/PR is welcome.
 
-### Note on `inList` and `notInList`
+## Set membership (`inList`, `notInList`)
+
+Test whether a value is present in (or absent from) a collection.
+
+```kotlin
+val foodOrCoffee = merchants.select(
+    where = Merchant::category inList listOf("Food", "Coffee"),
+).first()
+```
 
 The DSL operator is `inList` (not `in`) because `in` is a Kotlin keyword.
 `notInList` exists in two forms — infix on a path builder, and a regular
@@ -93,7 +152,7 @@ Merchant::name.notInList(listOf("Alice", "Bob"))
 
 `notInList(emptyList())` matches **all** rows — there's nothing to exclude.
 
-## Boolean composition: `and`, `or`, `not`
+## Boolean composition (`and`, `or`, `not`)
 
 `Where<T>` values combine with two infix functions and one wrapper:
 
@@ -116,29 +175,33 @@ merchants.select(
 
 `and` and `or` are infix; `not(...)` is a regular function. Each combinator
 just nests the SQL — `(A AND B)`, `(A OR B)`, `NOT (A)` — so you can build
-arbitrarily deep predicates without any precedence surprises.
+arbitrarily deep predicates without precedence surprises.
 
 {: .highlight }
 > Prefer wrapping each operand in parentheses when mixing `and` and `or` —
 > Kotlin doesn't give infix functions special precedence, so
 > `a or b and c` reads left-to-right as `(a or b) and c`, not `a or (b and c)`.
 
-## Worked examples
+## Nested queries
 
-These mirror real tests in `KeyValueStorageTest.kt`. The original tests use a
-`TestObject` data class with `name`, `description`, `child.createdAt`, and a
-`list: List<Child>` — translated below to the `Merchant` shape used in the
-docs.
-
-### Equality on a top-level field
+Every operator that takes a `KProperty1` also accepts a `JsonPathBuilder<T>`,
+so the same operators work on nested objects and list elements:
 
 ```kotlin
-val byId = merchants.select(
-    where = Merchant::id eq "merchant-42",
+merchants.select(
+    where = Merchant::location.then(Location::city) eq "Brooklyn",
 ).first()
 ```
 
-Reference test: `select_byEntityId` — `where = TestObject::id eq expect.id`.
+The full path-builder reference (chaining, list-element traversal,
+`@SerialName` overrides, value classes, sealed classes) lives on its own
+page — [Nested fields]({{ '/guides/nested-fields/' | relative_url }}).
+
+## Worked examples
+
+Putting the operators together. These mirror real tests in
+`KeyValueStorageTest.kt` (translated from the test's `TestObject` shape into
+the `Merchant` shape used elsewhere in the docs).
 
 ### AND of two equality predicates
 
@@ -160,46 +223,6 @@ val hits = merchants.select(
 ).first()
 ```
 
-### `like` with wildcards
-
-```kotlin
-val starsomething = merchants.select(
-    where = Merchant::name like "Star%",
-).first()
-```
-
-`like` accepts the standard SQLite patterns — `%` for any sequence of chars,
-`_` for a single char. Bound as a string, so escape your input if it comes
-from users.
-
-### `inList` over a list of values
-
-```kotlin
-val foodOrCoffee = merchants.select(
-    where = Merchant::category inList listOf("Food", "Coffee"),
-).first()
-```
-
-### `inList` into nested list elements
-
-`inList` works on a path that ends inside a collection — every element gets
-checked. Extend the model with a `tags: List<Tag>` field to demonstrate:
-
-```kotlin
-@Serializable data class Tag(val name: String)
-@Serializable data class Merchant(
-    val id: String, val name: String, val category: String,
-    val score: Int = 0, val tags: List<Tag> = emptyList(),
-)
-
-val withTagged = merchants.select(
-    where = Merchant::tags.then(Tag::name) inList listOf("vegan", "halal"),
-).first()
-```
-
-(See [Nested fields]({{ '/guides/nested-fields/' | relative_url }}) for the
-list-traversal `.then(...)` overload.)
-
 ### Range with `gt` / `lt`
 
 ```kotlin
@@ -207,6 +230,16 @@ val midRange = merchants.select(
     where = (Merchant::score gt 50).and(Merchant::score lt 200),
 ).first()
 ```
+
+### Equality on a top-level field
+
+```kotlin
+val byId = merchants.select(
+    where = Merchant::id eq "merchant-42",
+).first()
+```
+
+Reference test: `select_byEntityId`.
 
 ## Common pitfalls
 
@@ -234,19 +267,6 @@ where = TestObject::child.then(TestObjectChild::createdAt) lt expect.child.creat
 The same applies to `gt`, `eq`, `inList`, and ordering — Sqkon binds whatever
 type you give it, and the JSON value is a string.
 
-### Comparing against `null`
-
-`eq` and `neq` accept a nullable value, so null comparison works as you'd
-expect:
-
-```kotlin
-val withoutDescription = merchants.select(
-    where = Merchant::description eq null,
-).first()
-```
-
-`gt` / `lt` against `null` is a runtime error in SQLite — don't do it.
-
 ### Enums
 
 Enums bind by **Kotlin name** (the default `kotlinx.serialization`
@@ -262,8 +282,28 @@ range scans on millions of rows are still O(n). See
 [Performance]({{ '/guides/performance/' | relative_url }}) for when to add a
 generated column / index.
 
+## Under the hood
+
+```mermaid
+flowchart LR
+    DSL["Merchant::name eq 'X'"] --> Where["Where&lt;Merchant&gt;"]
+    Where --> SQL["json_tree join: fullkey LIKE '$.name' AND value = 'X'"]
+    SQL --> Plan["SQLite query plan"]
+```
+
+A `Where<T>` is a typed AST node. When the store runs a query, every node is
+asked to emit a `SqlQuery` — a `FROM` (a `json_tree(entity.value, '$')` join),
+a `WHERE` predicate, and the bound parameters. AND/OR combine two child
+queries into one. The store also adds the `entity_name = ?` filter for the
+store you opened, so two stores in the same database never collide.
+
+For the full read/write lifecycle (serializer → SQLDelight → driver →
+SQLite), see
+[Concepts: Architecture]({{ '/concepts/architecture/' | relative_url }}).
+
 ## Where to next
 
 - [Nested fields]({{ '/guides/nested-fields/' | relative_url }}) — query into nested objects and list elements.
 - [Ordering]({{ '/guides/ordering/' | relative_url }}) — sort the results once your filter is right.
 - [Paging]({{ '/guides/paging/' | relative_url }}) — when the result set gets too big to load at once.
+- [Performance]({{ '/guides/performance/' | relative_url }}) — keep queries cheap as the store grows.

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -77,11 +77,10 @@ emission.
 
 ## Flow emission timing
 
-Flows emit **after the transaction commits**, not while it's running. Inside a
-`transaction { … }` you can perform multiple writes and observers will see a
-single re-execution once the block returns. See
-[Reactive flows]({{ '/guides/flow/' | relative_url }}) for the underlying
-notification mechanism.
+Flows emit **after** the transaction commits, never mid-transaction — observers
+see one re-execution per committed block, regardless of how many writes it
+contained. The full notification mechanism (and the bulk-write guarantees) lives
+in [Reactive flows: when does it re-emit?]({{ '/guides/flow/#when-does-it-re-emit' | relative_url }}).
 
 ## Synchronous transactions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,8 @@ dependencies {
 
 ## 30-second taste
 
+Android needs a `Context`; JVM needs a `CoroutineScope`. See [Platform setup]({{ '/getting-started/platform-setup/' | relative_url }}) for both.
+
 ```kotlin
 @Serializable
 data class Merchant(
@@ -41,7 +43,7 @@ data class Merchant(
     val category: String,
 )
 
-// Android needs context + scope; JVM needs scope only.
+// Android needs a Context + scope; JVM needs a scope only.
 val sqkon = Sqkon(context = applicationContext, scope = appScope)
 val merchants = sqkon.keyValueStorage<Merchant>("merchants")
 
@@ -63,30 +65,30 @@ suspend fun loadFood(): List<Merchant> =
 ## Why Sqkon?
 
 <div class="feature-grid">
-  <div class="feature-card">
+  <a class="feature-card" href="{{ '/getting-started/platform-setup/' | relative_url }}">
     <h3>Kotlin Multiplatform</h3>
     <p>One codebase, Android + JVM. iOS on the roadmap.</p>
-  </div>
-  <div class="feature-card">
+  </a>
+  <a class="feature-card" href="{{ '/guides/querying/' | relative_url }}">
     <h3>JSONB queries</h3>
     <p>Query nested fields and lists with a type-safe DSL — no manual SQL, no DAOs.</p>
-  </div>
-  <div class="feature-card">
+  </a>
+  <a class="feature-card" href="{{ '/guides/flow/' | relative_url }}">
     <h3>Reactive Flows</h3>
     <p>Every read returns a <code>Flow</code>. Writes auto-invalidate observers.</p>
-  </div>
-  <div class="feature-card">
+  </a>
+  <a class="feature-card" href="{{ '/guides/paging/' | relative_url }}">
     <h3>AndroidX Paging</h3>
     <p>Built-in keyset and offset <code>PagingSource</code>s for Compose and views.</p>
-  </div>
-  <div class="feature-card">
+  </a>
+  <a class="feature-card" href="{{ '/guides/expiry/' | relative_url }}">
     <h3>TTL / Expiry</h3>
     <p>First-class expiry on every entry. Perfect for caches.</p>
-  </div>
-  <div class="feature-card">
+  </a>
+  <a class="feature-card" href="{{ '/concepts/architecture/' | relative_url }}">
     <h3>Built on SQLDelight</h3>
     <p>Battle-tested SQLite, with type-safe codegen underneath.</p>
-  </div>
+  </a>
 </div>
 
 ## Next steps
@@ -94,4 +96,6 @@ suspend fun loadFood(): List<Merchant> =
 - [Quickstart →]({{ '/getting-started/quickstart/' | relative_url }})
 - [What it is, what it isn't →]({{ '/concepts/what-it-is/' | relative_url }})
 - [Querying with JsonPath →]({{ '/guides/querying/' | relative_url }})
+- [Compare with Room, DataStore, Realm, MMKV →]({{ '/concepts/comparison/' | relative_url }})
+- [Platform setup (Android & JVM) →]({{ '/getting-started/platform-setup/' | relative_url }})
 - [API reference →]({{ '/api/' | relative_url }})


### PR DESCRIPTION
## Summary

Round of post-launch polish on the GitHub Pages site addressing user-reported issues with discoverability, structure, and a broken mermaid diagram.

- **Sidebar logo:** custom `_includes/title.html` renders the logo to the left of the "Sqkon" title (JTD's default shows logo *or* title, not both). `<img>` carries explicit `width`/`height` to prevent CLS.
- **Why Sqkon cards now go somewhere:** the six landing-page cards changed from inert `<div>`s to `<a class="feature-card">` links pointing at the relevant docs (Platform setup, Querying, Flow, Paging, Expiry, Architecture).
- **Comparison & Platform Setup discoverability:** added explicit links from the home page's "Next steps" plus a prose pointer to Platform setup under the 30-second taste — both pages had full content but no inbound links from the landing page.
- **Comparison accuracy:** added footnotes that Realm Kotlin is now distributed as the MongoDB Atlas Device SDK and that DataStore Multiplatform is in active upstream development.
- **Querying restructure:** reordered simple → complex with an "Operators at a glance" jump-link table at the top, per-operator sections, then composition, nested queries, worked examples, pitfalls, and "Under the hood" demoted to the bottom.
- **Mermaid fix:** `docs/guides/flow.md` sequenceDiagram alias `KeyValueStorage&lt;T&gt;` rendered with literal `&lt;` because Mermaid 10.x does not decode HTML entities inside participant labels — switched to `KeyValueStorage(T)`.
- **Overlap dedupe:** Transactions' "Flow emission timing" collapsed to a one-paragraph link into Flow's canonical "When does it re-emit?"; Architecture's duplicate index list trimmed to a link into Performance; the `inList`-on-nested-list example moved to its canonical home in Nested fields.
- **A11y:** `.feature-card` link cards get a `:focus-visible` outline using `$mercury-accent`.

## Why

User feedback flagged Comparison and Platform Setup as "blank or links broken" (it was actually a discoverability problem — the pages exist on disk but had no inbound links from the home page), the Why Sqkon cards as "feel like they should go somewhere", a broken mermaid in `flow.md`, querying as needing better simple→complex progression with quicker jump links, and overlap between several guides. All addressed here.

A separate follow-up PR will add a `:benchmark` Gradle module (kotlinx-benchmark/JMH) and fold measured numbers back into `docs/guides/performance.md` to address the "we should probably create real benchmarks" item.

## Test plan

- [ ] `bundle exec jekyll build` runs clean (only pre-existing upstream JTD Sass deprecation warnings).
- [ ] Sidebar shows logo image to the left of "Sqkon" text.
- [ ] All six Why Sqkon cards on the home page are clickable and land on the correct docs page.
- [ ] "Compare with Room, DataStore, Realm, MMKV →" and "Platform setup (Android & JVM) →" appear under Next steps and route correctly.
- [ ] `/guides/flow/` mermaid sequenceDiagram renders (writer → SqkonStore → SQLDelight → reader); browser console free of mermaid parse errors.
- [ ] `/guides/querying/` shows the operators jump table near the top; all five anchors (`#equality-eq-neq`, `#string-matching-like`, `#numeric-comparison-gt-lt`, `#set-membership-inlist-notinlist`, `#boolean-composition-and-or-not`) scroll to the right section.
- [ ] `/concepts/comparison/` renders the Realm and DataStore footnotes at the bottom.
- [ ] No layout shift on logo load (width/height attrs reserve space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)