### PR TITLE
fix: Not predicate inverts per-entity (was broken by json_tree row explosion)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -331,14 +331,16 @@ inline infix fun <reified T : Any, reified V, VALUE> KProperty1<T, V>.lt(value: 
  * This just wraps the passed in where clause.
  */
 data class Not<T : Any>(private val where: Where<T>) : Where<T>() {
+    // Delegate to the inner Where's scalar form (json_extract-based, no json_tree join).
+    // Wrapping the json_tree form with NOT(...) is unsound: a single entity produces many
+    // json_tree rows, and NOT is satisfied by any non-target row, so every entity matches.
     override fun toSqlQuery(increment: Int): SqlQuery {
-        val query = where.toSqlQuery(increment)
+        val inner = where.toScalarSqlValue()
         return SqlQuery(
-            from = query.from,
-            where = "NOT (${query.where})",
-            parameters = query.parameters,
-            bindArgs = query.bindArgs,
-            orderBy = query.orderBy
+            from = null,
+            where = "(NOT ${inner.sql})",
+            parameters = inner.parameters,
+            bindArgs = { inner.bindArgs(this) },
         )
     }
 

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -159,3 +159,24 @@ data class Shipment(
     val returnedAt: Long? = null,
     val flagged: Boolean = false,
 )
+
+/**
+ * Designed to serialize to a JSON payload > 1 MB so the 1MB-blob round-trip test
+ * exercises BLOB I/O end-to-end. Default `payload` is a 1 MiB ASCII string.
+ */
+@Serializable
+data class LargeTestObject(
+    val id: String,
+    val payload: String = "x".repeat(1 shl 20), // 1 MiB
+)
+
+/**
+ * All-nullable fields for IS NULL / IS NOT NULL operator coverage.
+ */
+@Serializable
+data class NullableTestObject(
+    val id: String,
+    val name: String? = null,
+    val count: Int? = null,
+    val flag: Boolean? = null,
+)

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TransactionTestExt.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TransactionTestExt.kt
@@ -1,0 +1,45 @@
+package com.mercury.sqkon
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verify commit-visibility ordering:
+ *  1. [flow] emits [initial] before any write.
+ *  2. During [commit] (a slow write), [reader] still observes [initial].
+ *  3. After [commit] returns, [flow] emits a value matching [matchPost] and a follow-up
+ *     [reader] call observes the same.
+ *
+ * Used to pin the "reader sees pre-commit snapshot until commit" SQLite WAL behavior.
+ */
+suspend fun <T> assertVisibilityOrder(
+    flow: Flow<T>,
+    initial: T,
+    commit: suspend () -> Unit,
+    reader: suspend () -> T,
+    matchPost: (T) -> Boolean,
+) = coroutineScope {
+    flow.test(timeout = 10.seconds) {
+        assertEquals(initial, awaitItem())
+        val midRead = async(Dispatchers.Default) {
+            delay(20.milliseconds) // let commit() start
+            reader()
+        }
+        commit()
+        // mid-commit reader must have seen the pre-commit snapshot
+        assertEquals(initial, midRead.await())
+        // post-commit emission
+        val post = awaitItem()
+        check(matchPost(post)) { "post-commit flow emission did not match: $post" }
+        // post-commit reader sees the new value
+        check(matchPost(reader())) { "post-commit reader did not match" }
+        cancelAndIgnoreRemainingEvents()
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TransactionTestExt.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TransactionTestExt.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -37,9 +38,9 @@ suspend fun <T> assertVisibilityOrder(
         assertEquals(initial, midRead.await())
         // post-commit emission
         val post = awaitItem()
-        check(matchPost(post)) { "post-commit flow emission did not match: $post" }
+        assertTrue(matchPost(post), "post-commit flow emission did not match: $post")
         // post-commit reader sees the new value
-        check(matchPost(reader())) { "post-commit reader did not match" }
+        assertTrue(matchPost(reader()), "post-commit reader did not match")
         cancelAndIgnoreRemainingEvents()
     }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TurbineExt.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TurbineExt.kt
@@ -1,0 +1,34 @@
+package com.mercury.sqkon
+
+import app.cash.turbine.ReceiveTurbine
+import kotlinx.coroutines.delay
+import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Assert no item is emitted within [window]. Use to prove that a write to one store
+ * does NOT trigger a Flow over a different store. Drains anything already queued first.
+ */
+suspend fun <T> ReceiveTurbine<T>.expectNoEventsBriefly(
+    window: Duration = 200.milliseconds,
+) {
+    delay(window)
+    expectNoEvents()
+}
+
+/**
+ * Poll [awaitItem] up to [timeout] until [predicate] matches; fail otherwise.
+ */
+suspend fun <T> ReceiveTurbine<T>.awaitItemMatching(
+    timeout: Duration = 5.seconds,
+    predicate: (T) -> Boolean,
+): T {
+    val deadline = kotlin.time.TimeSource.Monotonic.markNow() + timeout
+    while (deadline.hasNotPassedNow()) {
+        val item = awaitItem()
+        if (predicate(item)) return item
+    }
+    fail("No item matched within $timeout")
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TurbineExt.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TurbineExt.kt
@@ -1,7 +1,10 @@
 package com.mercury.sqkon
 
 import app.cash.turbine.ReceiveTurbine
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -10,25 +13,37 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Assert no item is emitted within [window]. Use to prove that a write to one store
  * does NOT trigger a Flow over a different store. Drains anything already queued first.
+ *
+ * The delay runs on [Dispatchers.Default] so virtual-time test schedulers cannot
+ * short-circuit the wall-clock window.
  */
 suspend fun <T> ReceiveTurbine<T>.expectNoEventsBriefly(
     window: Duration = 200.milliseconds,
 ) {
-    delay(window)
+    withContext(Dispatchers.Default) {
+        delay(window)
+    }
     expectNoEvents()
 }
 
 /**
  * Poll [awaitItem] up to [timeout] until [predicate] matches; fail otherwise.
+ *
+ * Each iteration is bounded by the remaining time via [withTimeoutOrNull] so the
+ * helper's [timeout] parameter actually caps wall-clock wait rather than being
+ * dominated by Turbine's own global timeout.
  */
 suspend fun <T> ReceiveTurbine<T>.awaitItemMatching(
     timeout: Duration = 5.seconds,
     predicate: (T) -> Boolean,
 ): T {
-    val deadline = kotlin.time.TimeSource.Monotonic.markNow() + timeout
-    while (deadline.hasNotPassedNow()) {
-        val item = awaitItem()
+    val start = kotlin.time.TimeSource.Monotonic.markNow()
+    while (true) {
+        val elapsed = start.elapsedNow()
+        if (elapsed >= timeout) fail("No item matched within $timeout")
+        val remaining = timeout - elapsed
+        val item = withTimeoutOrNull(remaining) { awaitItem() }
+            ?: fail("No item matched within $timeout (awaitItem timed out)")
         if (predicate(item)) return item
     }
-    fail("No item matched within $timeout")
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/ConcurrencyTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/ConcurrencyTest.kt
@@ -1,0 +1,83 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.assertVisibilityOrder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Ignore
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class ConcurrencyTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("conc", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() {
+        entityQueries.slowWrite = false
+        mainScope.cancel()
+    }
+
+    @Test
+    fun slowWriter_doesNotBlockFourParallelReaders() = runTest(timeout = 15.seconds) {
+        store.insert("seed", TestObject())
+        entityQueries.slowWrite = true
+
+        coroutineScope {
+            val readers = (1..4).map {
+                async(Dispatchers.IO) {
+                    withContext(Dispatchers.IO) { store.count().first() }
+                }
+            }
+            val writer = async(Dispatchers.IO) {
+                store.insert("w", TestObject())
+            }
+            val results = readers.awaitAll()
+            writer.await()
+            results.forEach { assertTrue(it >= 1) }
+        }
+        entityQueries.slowWrite = false
+        assertEquals(2, store.count().first())
+    }
+
+    // DISCOVERY (MOB-3287): The slowWrite Thread.sleep(100) fires after driver.execute() completes
+    // within the transaction block. SQLDelight's driver.execute() inside transaction{} commits the
+    // SQL before returning, so any concurrent reader observes the new value immediately — even
+    // during the sleep. WAL MultipleReadersSingleWriter is active but the write lock is released
+    // before the 20 ms delay in assertVisibilityOrder fires, so the "pre-commit snapshot" invariant
+    // cannot be exercised with the current slowWrite hook placement.
+    @Ignore("pre-commit snapshot not reachable via slowWrite — see comment above")
+    @Test
+    fun readerSeesPreCommitSnapshot_untilCommit() = runTest(timeout = 15.seconds) {
+        store.insert("seed", TestObject(name = "before"))
+        entityQueries.slowWrite = true
+
+        val seedFlow = store.selectByKey("seed").filterNotNull()
+        val initialValue: TestObject = seedFlow.first().also {
+            check(it.name == "before") { "seed corrupted" }
+        }
+        assertVisibilityOrder(
+            flow = seedFlow,
+            initial = initialValue,
+            commit = {
+                store.update("seed", TestObject(id = "seed", name = "after"))
+            },
+            reader = { store.selectByKey("seed").first()!! },
+            matchPost = { it.name == "after" },
+        )
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/EntityQueriesNotifyTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/EntityQueriesNotifyTest.kt
@@ -1,0 +1,53 @@
+package com.mercury.sqkon.db
+
+import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.expectNoEventsBriefly
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class EntityQueriesNotifyTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storeA = keyValueStorage<TestObject>("store-a", entityQueries, metadataQueries, mainScope)
+    private val storeB = keyValueStorage<TestObject>("store-b", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() { mainScope.cancel() }
+
+    @Test
+    fun writeToStoreA_doesNotEmitOnFlowOverStoreB() = runTest {
+        turbineScope {
+            val flowB = storeB.selectAll().testIn(backgroundScope)
+            assertEquals(emptyList(), flowB.awaitItem()) // initial
+
+            storeA.insert("k1", TestObject())
+
+            flowB.expectNoEventsBriefly()
+            flowB.cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun sameNameCrossInstanceWrite_doesEmit() = runTest {
+        // Two KeyValueStorage instances over the SAME driver and SAME entityName must
+        // share the driver-level "entity_<name>" listener.
+        val storeA2 = keyValueStorage<TestObject>("store-a", entityQueries, metadataQueries, mainScope)
+        storeA.selectAll().test {
+            assertEquals(emptyList(), awaitItem())
+            val expected = TestObject()
+            storeA2.insert(expected.id, expected)
+            val emitted = awaitItem()
+            assertEquals(1, emitted.size)
+            assertEquals(expected, emitted.first())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonbStorageTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonbStorageTest.kt
@@ -1,0 +1,115 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.db.QueryResult
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.TestObjectChild
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the SQLite JSON1 contract used by Sqkon:
+ * - jsonb() round-trip via insert/select
+ * - json_extract scalar on top-level fields
+ * - json_tree.fullkey agreement with JsonPathBuilder.buildPath()
+ *
+ * Uses EntityQueries.sqlDriver (@PublishedApi internal) for direct SQL.
+ */
+class JsonbStorageTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>(
+        "jsonb", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    /**
+     * Basic insert → select round-trip through jsonb() + json_extract().
+     * Verifies the JSONB encoding does not corrupt field values.
+     */
+    @Test
+    fun jsonbRoundTrip_preservesAllFields() = runTest {
+        val expected = TestObject()
+        store.insert(expected.id, expected)
+        val actual = store.selectByKey(expected.id).first()
+        assertEquals(expected, actual)
+    }
+
+    /**
+     * Verifies json_extract() can pull top-level scalar fields from the JSONB column.
+     * SQLite stores the value as JSONB; json_extract converts back for reading.
+     */
+    @Test
+    fun jsonExtract_returnsTopLevelScalar() = runTest {
+        val expected = TestObject(name = "alpha", value = 42)
+        store.insert(expected.id, expected)
+
+        // SqlCursor.next() returns QueryResult<Boolean> in SQLDelight 2.3.x — use .value
+        val cursor = entityQueries.sqlDriver.executeQuery(
+            identifier = null,
+            sql = "SELECT json_extract(value, '$.name'), json_extract(value, '$.value') " +
+                "FROM entity WHERE entity_key = ?",
+            mapper = { c ->
+                c.next().value  // advance; returns Boolean (ignored here — row must exist)
+                QueryResult.Value(Pair(c.getString(0)!!, c.getLong(1)!!))
+            },
+            parameters = 1,
+        ) { bindString(0, expected.id) }.value
+
+        assertEquals("alpha", cursor.first)
+        assertEquals(42L, cursor.second)
+    }
+
+    /**
+     * Confirms that JsonPathBuilder.buildPath() produces paths that match the actual
+     * json_tree.fullkey values present in the stored JSONB row.
+     *
+     * Observed buildPath() values (verified by running, not aspirational):
+     *   TestObject::name            → "$.name"
+     *   TestObject::value           → "$.value"
+     *   TestObject::child + createdAt → "$.child.createdAt"
+     */
+    @Test
+    fun jsonTreeFullkey_matchesJsonPathBuilder() = runTest {
+        store.insert("k", TestObject())
+
+        // builder() is a top-level inline extension on KProperty1<R,V>
+        // then() is a top-level inline extension that chains two properties
+        val cases: List<Pair<JsonPathBuilder<*>, String>> = listOf(
+            TestObject::name.builder<TestObject, String>() to "$.name",
+            TestObject::value.builder<TestObject, Int>() to "$.value",
+            TestObject::child.then(TestObjectChild::createdAt) to "$.child.createdAt",
+        )
+
+        cases.forEach { (builder, expectedPath) ->
+            assertEquals(
+                expectedPath,
+                builder.buildPath(),
+                "buildPath() mismatch — JsonPathBuilder drifted from expected JSON path",
+            )
+
+            // json_tree rows for a JSONB cell: fullkey holds the dotted path
+            val found = entityQueries.sqlDriver.executeQuery(
+                identifier = null,
+                sql = "SELECT 1 FROM entity, json_tree(entity.value, '\$') AS jt " +
+                    "WHERE entity_key = 'k' AND jt.fullkey = ? LIMIT 1",
+                mapper = { c -> QueryResult.Value(c.next().value) },
+                parameters = 1,
+            ) { bindString(0, expectedPath) }.value
+
+            assertTrue(found == true, "json_tree.fullkey missing path $expectedPath")
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEdgeCasesTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEdgeCasesTest.kt
@@ -1,0 +1,86 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.LargeTestObject
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+class KeyValueStorageEdgeCasesTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("edge", entityQueries, metadataQueries, mainScope)
+    private val largeStore = keyValueStorage<LargeTestObject>("large", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() { mainScope.cancel() }
+
+    @Test
+    fun insert_ignoreIfExistsTrue_isNoOp() = runTest {
+        val first = TestObject(id = "k", name = "first")
+        val second = TestObject(id = "k", name = "second")
+        store.insert("k", first)
+        store.insert("k", second, ignoreIfExists = true)
+        val actual = store.selectByKey("k").first()!!
+        assertEquals("first", actual.name)
+    }
+
+    @Test
+    fun insert_ignoreIfExistsFalse_throwsOnDuplicate() = runTest {
+        val first = TestObject(id = "k", name = "first")
+        val second = TestObject(id = "k", name = "second")
+        store.insert("k", first)
+        val ex = assertFails {
+            store.insert("k", second, ignoreIfExists = false)
+        }
+        assertTrue(
+            ex::class.java.name.contains("SQLite") || ex.message?.contains("UNIQUE") == true
+                    || ex.message?.contains("PRIMARY KEY") == true,
+            "unexpected exception type ${ex::class}: $ex",
+        )
+    }
+
+    @Test
+    fun specialCharacterKeys_roundTrip() = runTest {
+        val keys = listOf(
+            "unicode-emoji-🚀-key",
+            "single'quote",
+            "back\\slash",
+            "newline\nkey",
+            "nullbyte-ish",
+            "中文-key",
+        )
+        keys.forEachIndexed { i, k -> store.insert(k, TestObject(id = "id$i")) }
+        keys.forEachIndexed { i, k ->
+            val v = store.selectByKey(k).first()
+            assertEquals("id$i", v?.id, "key '$k' did not round-trip")
+        }
+    }
+
+    @Test
+    fun oneMegabyteBlob_roundTrips() = runTest {
+        val obj = LargeTestObject(id = "big", payload = "x".repeat(1 shl 20))
+        largeStore.insert(obj.id, obj)
+        val actual = largeStore.selectByKey(obj.id).first()!!
+        assertEquals(obj.payload.length, actual.payload.length)
+        assertEquals(obj, actual)
+    }
+
+    // EntityQueries.kt:148-149: when (entityKeys?.size) { null, 0 -> {} } — no key filter added,
+    // so an empty list returns ALL rows for the entity, same as selectAll().
+    @Test
+    fun selectByKeys_emptyList_returnsAllRowsForEntity() = runTest {
+        val items = (1..3).map { TestObject(id = "id$it") }
+        store.insertAll(items.associateBy { it.id })
+        val result = store.selectByKeys(emptyList()).first()
+        assertEquals(3, result.size)
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageMetadataPerRowTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageMetadataPerRowTest.kt
@@ -1,0 +1,116 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.db.QueryResult
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.until
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KeyValueStorageMetadataPerRowTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("md", entityQueries, metadataQueries, mainScope)
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    private fun rowMeta(key: String): Pair<Long?, Long?> {
+        var readAt: Long? = null
+        var writeAt: Long? = null
+        entityQueries.sqlDriver.executeQuery(
+            identifier = null,
+            sql = "SELECT read_at, write_at FROM entity WHERE entity_key = ? AND entity_name = 'md'",
+            mapper = { c ->
+                c.next().value  // advance cursor — returns Boolean in SQLDelight 2.3.x
+                readAt = c.getLong(0)
+                writeAt = c.getLong(1)
+                QueryResult.Unit
+            },
+            parameters = 1,
+        ) { bindString(0, key) }
+        return readAt to writeAt
+    }
+
+    @Test
+    fun insert_setsWriteAt_leavesReadAtNull() = runTest {
+        val obj = TestObject()
+        store.insert(obj.id, obj)
+        val (readAt, writeAt) = rowMeta(obj.id)
+        assertNotNull(writeAt)
+        assertNull(readAt)
+    }
+
+    @Test
+    fun select_updatesReadAt() = runTest {
+        val obj = TestObject()
+        store.insert(obj.id, obj)
+        store.selectByKey(obj.id).first()
+        until { rowMeta(obj.id).first != null }
+        val (readAt, _) = rowMeta(obj.id)
+        assertNotNull(readAt)
+    }
+
+    @Test
+    fun count_doesNotUpdateReadAt() = runTest {
+        val obj = TestObject()
+        store.insert(obj.id, obj)
+        store.count().first()
+        delay(100)
+        val (readAt, _) = rowMeta(obj.id)
+        assertNull(readAt)
+    }
+
+    @Test
+    fun update_advancesWriteAt() = runTest {
+        val obj = TestObject()
+        store.insert(obj.id, obj)
+        val firstWrite = rowMeta(obj.id).second!!
+        delay(5)
+        store.update(obj.id, obj.copy(name = "new"))
+        val secondWrite = rowMeta(obj.id).second!!
+        assertTrue(secondWrite >= firstWrite)
+    }
+
+    @Test
+    fun deleteExpired_fires_metadataWrite() = runTest {
+        val past = Clock.System.now().minus(1.seconds)
+        val obj = TestObject()
+        store.insert(obj.id, obj, expiresAt = past)
+        val before = store.metadata().first().lastWriteAt
+        store.deleteExpired()
+        until { store.metadata().first().lastWriteAt != before }
+        val afterWriteAt = store.metadata().first().lastWriteAt
+        val fallback = Instant.fromEpochMilliseconds(0)
+        assertTrue((afterWriteAt ?: fallback) > (before ?: fallback))
+        assertEquals(0, store.count().first())
+    }
+
+    @Test
+    fun deleteStale_fires_metadataWrite() = runTest {
+        val obj = TestObject()
+        store.insert(obj.id, obj)
+        val before = store.metadata().first().lastWriteAt
+        store.deleteStale(
+            writeInstant = Clock.System.now(),
+            readInstant = Clock.System.now(),
+        )
+        until { store.metadata().first().lastWriteAt != before }
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
@@ -1,0 +1,99 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+class KeyValueStorageTransactionTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>("tx", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() { mainScope.cancel() }
+
+    @Test
+    fun rollback_leavesCountAtZero() = runTest {
+        // SQLDelight rollback() aborts the transaction silently — no exception propagated to caller.
+        storage.transaction {
+            storage.insert("k1", TestObject())
+            storage.insert("k2", TestObject())
+            rollback()
+        }
+        assertEquals(0, storage.count().first())
+    }
+
+    @Test
+    fun nestedRollback_rollsBackInnerOnly_perSqlDelightSemantics() = runTest {
+        storage.transaction {
+            storage.insert("outer", TestObject())
+            storage.transaction {
+                storage.insert("inner", TestObject())
+                rollback()
+            }
+        }
+        val count = storage.count().first()
+        // Observed: SQLDelight propagates RollbackException from inner tx to outer tx, rolling back
+        // the entire enclosing transaction — no savepoint semantics. Count must be 0.
+        assertEquals(0, count) // observed value pinned in Phase 0 — change requires a migration ADR
+    }
+
+    @Test
+    fun afterCommit_firesAfterCommitVisibleToReaders() = runTest {
+        val seen = AtomicInteger(0)
+        storage.transaction {
+            storage.insert("k", TestObject())
+            afterCommit {
+                // by the time this fires, the write must be visible
+                val visible = kotlinx.coroutines.runBlocking { storage.count().first() }
+                check(visible == 1) { "afterCommit ran before commit visible: $visible" }
+                seen.incrementAndGet()
+            }
+        }
+        // give afterCommit microtask time to land
+        kotlinx.coroutines.delay(50)
+        assertEquals(1, seen.get())
+    }
+
+    @Test
+    fun afterCommit_doesNotFireOnRollback() = runTest {
+        val fired = AtomicInteger(0)
+        runCatching {
+            storage.transaction {
+                storage.insert("k", TestObject())
+                afterCommit { fired.incrementAndGet() }
+                rollback()
+            }
+        }
+        kotlinx.coroutines.delay(50)
+        assertEquals(0, fired.get())
+        assertEquals(0, storage.count().first())
+    }
+
+    @Test
+    fun nestedTransaction_afterCommitFiresOnceAtOutermostCommit() = runTest {
+        val fired = AtomicInteger(0)
+        storage.transaction {
+            afterCommit { fired.incrementAndGet() }
+            storage.insert("outer", TestObject())
+            storage.transaction {
+                storage.insert("inner", TestObject())
+                afterCommit { fired.incrementAndGet() }
+            }
+            // at this point neither afterCommit should have run yet
+            assertEquals(0, fired.get())
+        }
+        kotlinx.coroutines.delay(50)
+        // Both callbacks registered; both must fire after the OUTERMOST commit.
+        assertEquals(2, fired.get())
+    }
+
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageWhereOperatorsTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageWhereOperatorsTest.kt
@@ -64,20 +64,15 @@ class KeyValueStorageWhereOperatorsTest {
     }
 
     @Test
-    fun not_select_isBrokenForJsonTreeJoin() = runTest {
-        // KNOWN BUG (MOB-3287): Not.toSqlQuery() wraps the json_tree WHERE with NOT (...),
-        // but a single entity has many json_tree rows (id, name, value, …). The NOT condition
-        // is satisfied by any non-matching row, so every entity is returned regardless.
-        // not(eq 30) should return 4 items but actually returns all 5.
-        // neq 30 is the correct way to exclude a value (returns 4 as expected).
+    fun not_invertsPredicate() = runTest {
         seedTestObjects()
         val viaNeq = store.select(where = TestObject::value neq 30).first()
         assertEquals(4, viaNeq.size)
         assertTrue(viaNeq.none { it.value == 30 })
 
-        // Document broken not() behaviour — returns ALL items rather than inverted set
         val viaNot = store.select(where = not(TestObject::value eq 30)).first()
-        assertEquals(5, viaNot.size) // all 5 returned — bug
+        assertEquals(4, viaNot.size)
+        assertTrue(viaNot.none { it.value == 30 })
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageWhereOperatorsTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageWhereOperatorsTest.kt
@@ -1,0 +1,116 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.NullableTestObject
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KeyValueStorageWhereOperatorsTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("ops", entityQueries, metadataQueries, mainScope)
+    private val nullStore = keyValueStorage<NullableTestObject>("nulls", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() { mainScope.cancel() }
+
+    private suspend fun seedTestObjects(): List<TestObject> {
+        val items = (1..5).map { i ->
+            TestObject(
+                id = "id$i",
+                name = "Name$i",
+                value = i * 10,
+            )
+        }
+        store.insertAll(items.associateBy { it.id })
+        return items
+    }
+
+    @Test
+    fun notEq_excludesMatchingValue() = runTest {
+        val items = seedTestObjects()
+        val result = store.select(where = TestObject::value neq 30).first()
+        assertEquals(4, result.size)
+        assertTrue(result.none { it.value == 30 })
+    }
+
+    @Test
+    fun like_matchesPattern() = runTest {
+        seedTestObjects()
+        val result = store.select(where = TestObject::name like "Name%").first()
+        assertEquals(5, result.size)
+    }
+
+    @Test
+    fun gt_lt_haveCorrectBoundaries() = runTest {
+        seedTestObjects()
+        // gt 30: values 40, 50 → 2
+        assertEquals(2, store.select(where = TestObject::value gt 30).first().size)
+        // lt 30: values 10, 20 → 2
+        assertEquals(2, store.select(where = TestObject::value lt 30).first().size)
+        // gt 20 AND lt 50: values 30, 40 → 2
+        assertEquals(
+            2,
+            store.select(where = (TestObject::value gt 20) and (TestObject::value lt 50)).first().size,
+        )
+    }
+
+    @Test
+    fun not_select_isBrokenForJsonTreeJoin() = runTest {
+        // KNOWN BUG (MOB-3287): Not.toSqlQuery() wraps the json_tree WHERE with NOT (...),
+        // but a single entity has many json_tree rows (id, name, value, …). The NOT condition
+        // is satisfied by any non-matching row, so every entity is returned regardless.
+        // not(eq 30) should return 4 items but actually returns all 5.
+        // neq 30 is the correct way to exclude a value (returns 4 as expected).
+        seedTestObjects()
+        val viaNeq = store.select(where = TestObject::value neq 30).first()
+        assertEquals(4, viaNeq.size)
+        assertTrue(viaNeq.none { it.value == 30 })
+
+        // Document broken not() behaviour — returns ALL items rather than inverted set
+        val viaNot = store.select(where = not(TestObject::value eq 30)).first()
+        assertEquals(5, viaNot.size) // all 5 returned — bug
+    }
+
+    @Test
+    fun andOrNesting_evaluatesLeftToRight() = runTest {
+        seedTestObjects()
+        // (value > 19 AND value < 41) OR value == 50  →  {20, 30, 40, 50}
+        val where = ((TestObject::value gt 19) and (TestObject::value lt 41)) or (TestObject::value eq 50)
+        val result = store.select(where = where).first()
+        assertEquals(setOf(20, 30, 40, 50), result.map { it.value }.toSet())
+    }
+
+    @Test
+    fun inList_emptyList_returnsNothing() = runTest {
+        seedTestObjects()
+        val result = store.select(where = TestObject::value inList emptyList<Int>()).first()
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun eqNull_matchesIsNull() = runTest {
+        nullStore.insert("a", NullableTestObject(id = "a", name = null))
+        nullStore.insert("b", NullableTestObject(id = "b", name = "set"))
+        val result = nullStore.select(where = NullableTestObject::name eq null).first()
+        assertEquals(1, result.size)
+        assertEquals("a", result.first().id)
+    }
+
+    @Test
+    fun neqNull_matchesIsNotNull() = runTest {
+        nullStore.insert("a", NullableTestObject(id = "a", name = null))
+        nullStore.insert("b", NullableTestObject(id = "b", name = "set"))
+        val result = nullStore.select(where = NullableTestObject::name neq null).first()
+        assertEquals(1, result.size)
+        assertEquals("b", result.first().id)
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/StatementCacheEvictionTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/StatementCacheEvictionTest.kt
@@ -1,0 +1,70 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class StatementCacheEvictionTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("cache", entityQueries, metadataQueries, mainScope)
+
+    @After fun tearDown() { mainScope.cancel() }
+
+    @Test
+    fun manyDistinctQueryShapes_concurrently_returnCorrectResults() = runTest(timeout = 30.seconds) {
+        val items = (0..49).map { TestObject(value = it) }.associateBy { it.id }
+        store.insertAll(items)
+
+        coroutineScope {
+            val results = (1..200).map { shapeIdx ->
+                async(Dispatchers.IO) {
+                    val limit = (shapeIdx % 50) + 1L
+                    val n = entityQueries.select(
+                        entityName = "cache",
+                        entityKeys = null,
+                        where = null,
+                        orderBy = emptyList(),
+                        limit = limit,
+                        offset = null,
+                        expiresAt = null,
+                    ).executeAsList().size
+                    shapeIdx to n
+                }
+            }.awaitAll()
+
+            results.forEach { (idx, n) ->
+                val expected = ((idx % 50) + 1).coerceAtMost(items.size)
+                assertEquals(expected, n, "shape $idx expected $expected rows, got $n")
+            }
+        }
+    }
+
+    @Test
+    fun parallelInsertUpdateDelete_acrossManyKeys_completesCleanly() = runTest(timeout = 30.seconds) {
+        coroutineScope {
+            (1..100).map { i ->
+                async(Dispatchers.IO) {
+                    val key = "k$i"
+                    store.insert(key, TestObject(id = key))
+                    store.update(key, TestObject(id = key, name = "updated$i"))
+                    store.deleteByKey(key)
+                }
+            }.awaitAll()
+        }
+        assertEquals(0, store.count().first())
+    }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaParityTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaParityTest.kt
@@ -1,0 +1,44 @@
+package com.mercury.sqkon.db
+
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+/**
+ * Boots a fresh v2 SqkonDatabase and dumps a deterministic, sorted text
+ * representation of the schema. Compared byte-for-byte against
+ * `library/src/jvmTest/resources/sqkon-schema-v2.snapshot`.
+ *
+ * Replaces `verifySqlDelightMigration` as the schema canary in Phase 4.
+ *
+ * To regenerate after an INTENTIONAL schema change:
+ *   1. Add a new SQLDelight migration .sqm file (bumps Schema.version).
+ *   2. Delete the snapshot file.
+ *   3. Re-run this test — it writes the new snapshot on first run.
+ *   4. Inspect the diff before committing.
+ */
+class SchemaParityTest {
+
+    private val snapshotPath = "src/jvmTest/resources/sqkon-schema-v2.snapshot"
+
+    @Test
+    fun freshSchema_matchesFixture() {
+        val driver = driverFactory().createDriver()
+        val actual = SchemaSnapshotUtil.dumpSchemaSnapshot(driver)
+
+        val file = File(snapshotPath)
+        if (!file.exists()) {
+            file.parentFile.mkdirs()
+            file.writeText(actual)
+            error(
+                "Snapshot did not exist; wrote new snapshot to $snapshotPath. " +
+                "Review and re-run."
+            )
+        }
+        val expected = file.readText()
+        assertEquals(
+            expected, actual,
+            "Schema drift detected. Diff vs $snapshotPath",
+        )
+    }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaSnapshotUtil.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaSnapshotUtil.kt
@@ -1,0 +1,139 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+
+internal object SchemaSnapshotUtil {
+
+    /**
+     * Deterministic, sorted text dump of the current SQLite schema. Used as a byte-for-byte
+     * fixture in SchemaParityTest and as the post-migration assertion in SchemaMigrationTest.
+     *
+     * Sections (each labeled with === name ===):
+     *   sqlite_master rows (excluding sqlite_% internals), sorted by (type, name)
+     *   PRAGMA table_info(entity), sorted by name
+     *   PRAGMA index_list(entity), sorted by name
+     *   PRAGMA table_info(metadata), sorted by name
+     *   PRAGMA user_version
+     */
+    fun dumpSchemaSnapshot(driver: SqlDriver): String = buildString {
+        appendLine("=== sqlite_master (excluding internal) ===")
+        sqliteMaster(driver).forEach { row ->
+            appendLine("[${row.type}] name=${row.name} tbl=${row.tblName}")
+            appendLine("  sql: ${normalise(row.sql)}")
+        }
+        appendLine()
+        appendLine("=== PRAGMA table_info(entity) ===")
+        pragmaTableInfo(driver, "entity").forEach { col ->
+            appendLine(formatTableInfo(col))
+        }
+        appendLine()
+        appendLine("=== PRAGMA index_list(entity) ===")
+        pragmaIndexList(driver, "entity").forEach { idx ->
+            appendLine(formatIndexList(idx))
+        }
+        appendLine()
+        appendLine("=== PRAGMA table_info(metadata) ===")
+        pragmaTableInfo(driver, "metadata").forEach { col ->
+            appendLine(formatTableInfo(col))
+        }
+        appendLine()
+        appendLine("=== PRAGMA user_version ===")
+        appendLine(pragmaUserVersion(driver))
+    }
+
+    private fun normalise(s: String?): String =
+        (s ?: "").replace(Regex("\\s+"), " ").trim()
+
+    private data class MasterRow(val type: String, val name: String, val tblName: String, val sql: String?)
+    private data class TableInfoRow(val cid: Long, val name: String, val type: String, val notnull: Long, val dflt: String?, val pk: Long)
+    private data class IndexListRow(val seq: Long, val name: String, val unique: Long, val origin: String, val partial: Long)
+
+    private fun sqliteMaster(driver: SqlDriver): List<MasterRow> {
+        val rows = mutableListOf<MasterRow>()
+        driver.executeQuery(
+            identifier = null,
+            sql = "SELECT type, name, tbl_name, sql FROM sqlite_master " +
+                  "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name",
+            mapper = { c ->
+                while (c.next().value) {
+                    rows += MasterRow(
+                        type = c.getString(0)!!,
+                        name = c.getString(1)!!,
+                        tblName = c.getString(2)!!,
+                        sql = c.getString(3),
+                    )
+                }
+                QueryResult.Unit
+            },
+            parameters = 0,
+        ) {}
+        return rows
+    }
+
+    private fun pragmaTableInfo(driver: SqlDriver, table: String): List<TableInfoRow> {
+        val rows = mutableListOf<TableInfoRow>()
+        driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA table_info($table)",
+            mapper = { c ->
+                while (c.next().value) {
+                    rows += TableInfoRow(
+                        cid = c.getLong(0)!!,
+                        name = c.getString(1)!!,
+                        type = c.getString(2)!!,
+                        notnull = c.getLong(3)!!,
+                        dflt = c.getString(4),
+                        pk = c.getLong(5)!!,
+                    )
+                }
+                QueryResult.Unit
+            },
+            parameters = 0,
+        ) {}
+        return rows.sortedBy { it.name }
+    }
+
+    private fun pragmaIndexList(driver: SqlDriver, table: String): List<IndexListRow> {
+        val rows = mutableListOf<IndexListRow>()
+        driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA index_list($table)",
+            mapper = { c ->
+                while (c.next().value) {
+                    rows += IndexListRow(
+                        seq = c.getLong(0)!!,
+                        name = c.getString(1)!!,
+                        unique = c.getLong(2)!!,
+                        origin = c.getString(3) ?: "",
+                        partial = c.getLong(4) ?: 0L,
+                    )
+                }
+                QueryResult.Unit
+            },
+            parameters = 0,
+        ) {}
+        return rows.sortedBy { it.name }
+    }
+
+    private fun pragmaUserVersion(driver: SqlDriver): Long {
+        var v = -1L
+        driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA user_version",
+            mapper = { c ->
+                c.next().value
+                v = c.getLong(0)!!
+                QueryResult.Unit
+            },
+            parameters = 0,
+        ) {}
+        return v
+    }
+
+    private fun formatTableInfo(c: TableInfoRow): String =
+        "cid=${c.cid} name=${c.name} type=${c.type} notnull=${c.notnull} default=${c.dflt ?: "null"} pk=${c.pk}"
+
+    private fun formatIndexList(i: IndexListRow): String =
+        "seq=${i.seq} name=${i.name} unique=${i.unique} origin=${i.origin} partial=${i.partial}"
+}

--- a/library/src/jvmTest/resources/sqkon-schema-v2.snapshot
+++ b/library/src/jvmTest/resources/sqkon-schema-v2.snapshot
@@ -1,0 +1,35 @@
+=== sqlite_master (excluding internal) ===
+[index] name=idx_entity_expires_at tbl=entity
+  sql: CREATE INDEX idx_entity_expires_at ON entity (expires_at)
+[index] name=idx_entity_read_at tbl=entity
+  sql: CREATE INDEX idx_entity_read_at ON entity (read_at)
+[index] name=idx_entity_write_at tbl=entity
+  sql: CREATE INDEX idx_entity_write_at ON entity (write_at)
+[table] name=entity tbl=entity
+  sql: CREATE TABLE entity ( entity_name TEXT NOT NULL, entity_key TEXT NOT NULL, -- UTC timestamp in milliseconds added_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, -- UTC timestamp in milliseconds updated_at INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, -- UTC timestamp in milliseconds expires_at INTEGER, -- JSONB Blob use jsonb_ operators value BLOB NOT NULL, -- UTC timestamp in milliseconds read_at INTEGER, -- UTC timestamp in milliseconds write_at INTEGER, PRIMARY KEY (entity_name, entity_key) )
+[table] name=metadata tbl=metadata
+  sql: CREATE TABLE metadata ( entity_name TEXT NOT NULL PRIMARY KEY, lastReadAt INTEGER, lastWriteAt INTEGER )
+
+=== PRAGMA table_info(entity) ===
+cid=2 name=added_at type=INTEGER notnull=1 default=CURRENT_TIMESTAMP pk=0
+cid=1 name=entity_key type=TEXT notnull=1 default=null pk=2
+cid=0 name=entity_name type=TEXT notnull=1 default=null pk=1
+cid=4 name=expires_at type=INTEGER notnull=0 default=null pk=0
+cid=6 name=read_at type=INTEGER notnull=0 default=null pk=0
+cid=3 name=updated_at type=INTEGER notnull=1 default=CURRENT_TIMESTAMP pk=0
+cid=5 name=value type=BLOB notnull=1 default=null pk=0
+cid=7 name=write_at type=INTEGER notnull=0 default=null pk=0
+
+=== PRAGMA index_list(entity) ===
+seq=0 name=idx_entity_expires_at unique=0 origin=c partial=0
+seq=2 name=idx_entity_read_at unique=0 origin=c partial=0
+seq=1 name=idx_entity_write_at unique=0 origin=c partial=0
+seq=3 name=sqlite_autoindex_entity_1 unique=1 origin=pk partial=0
+
+=== PRAGMA table_info(metadata) ===
+cid=0 name=entity_name type=TEXT notnull=1 default=null pk=1
+cid=1 name=lastReadAt type=INTEGER notnull=0 default=null pk=0
+cid=2 name=lastWriteAt type=INTEGER notnull=0 default=null pk=0
+
+=== PRAGMA user_version ===
+2


### PR DESCRIPTION
## Summary
- `Not.toSqlQuery` previously wrapped the json_tree-joined inner WHERE with `NOT (...)`. Because a single entity emits one json_tree row per JSON field, the `NOT` was satisfied by any non-target row, so `not(field eq X)` returned every entity regardless of value.
- Fix: delegate `Not.toSqlQuery` to the inner `Where`'s scalar form (`toScalarSqlValue`, which uses `json_extract` and no LATERAL join). NOT now evaluates exactly once per entity row.
- `neq` and `notInList` were unaffected — they already produced correct SQL without going through `Not`.

The preceding 11 commits on this branch are test-pinning commits that locked in current behaviour (including the known-broken `not(...)` case) so this fix could land with a clean diff.

## Test plan
- [x] `./gradlew :library:jvmTest` — `KeyValueStorageWhereOperatorsTest` all green (8/8). `not_invertsPredicate` (renamed from `not_select_isBrokenForJsonTreeJoin`) now asserts 4 items, not 5.
- [x] Verified `Eq`-with-null inversion: scalar form lowers to `IS NULL`, `NOT (IS NULL)` ≡ `IS NOT NULL`, matching `neq null` semantics.
- [ ] CI Android instrumented run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)