### PR TITLE
feat!: hide sqldelight transacter behind SqkonTransactionScope (MOB-3292)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -161,6 +161,39 @@ shipments.select(where = caseWhere(Shipment::status) {
 `caseWhere` is WHERE-only. Use the value-selection `case` if you need a
 single value to feed into `ORDER BY`.
 
+### Transactions
+
+Group multiple writes into one atomic transaction with the `transaction { }` extension. Inserts,
+updates and deletes inside the block commit together (or roll back together):
+
+```kotlin
+store.transaction {
+    store.deleteAll()
+    store.insertAll(newItems)
+}
+```
+
+`rollback()` aborts the transaction and discards the work:
+
+```kotlin
+store.transaction {
+    store.insert(key, value)
+    if (shouldAbort) rollback() // nothing is written; returns silently
+}
+```
+
+Use `afterCommit { }` / `afterRollback { }` to react once the outermost transaction settles, and
+`transactionWithResult { }` when you need a return value (here `rollback()` throws
+`SqkonRollbackException`, since there is no value to return):
+
+```kotlin
+val count: Int = store.transactionWithResult {
+    store.insertAll(items)
+    afterCommit { log("committed") }
+    items.size
+}
+```
+
 ## Paging
 
 Sqkon provides two `PagingSource` factories on `KeyValueStorage` that plug into AndroidX Paging 3:

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -8,9 +8,16 @@ nav_order: 7
 # Transactions
 {: .no_toc }
 
-Sqkon exposes SQLDelight's transaction API directly: `KeyValueStorage<T>`
-implements `Transacter`, so you can wrap multiple writes — across one store or
-many — in a single atomic block.
+Sqkon gives every `KeyValueStorage<T>` a `transaction { … }` extension, so you
+can wrap multiple writes — across one store or many — in a single atomic block.
+The block runs against a Sqkon-owned `SqkonTransactionScope`; no SQLDelight types
+are exposed.
+
+{: .note }
+**Changed in 2.0.** Stores no longer implement SQLDelight's `Transacter`. The
+`transaction { }` / `transactionWithResult { }` calls below are unchanged, but if
+you held a store as a `Transacter` or imported `TransactionCallbacks`, see
+[Upgrading from 1.x](#upgrading-from-1x).
 
 1. TOC
 {:toc}
@@ -31,8 +38,8 @@ already transactional.
 
 ## API
 
-`KeyValueStorage<T>` is `Transacter by transacter`, which means the standard
-SQLDelight transaction API is available on every store:
+Two extension functions on `KeyValueStorage<T>` open a transaction; the lambda
+receiver is [`SqkonTransactionScope`](#the-scope):
 
 ```kotlin
 merchants.transaction {
@@ -58,6 +65,48 @@ merchants.transaction {
 }
 // Both writes commit as one unit; observers on either store see one emission.
 ```
+
+### The scope
+
+Inside the block you have a `SqkonTransactionScope`:
+
+```kotlin
+sealed interface SqkonTransactionScope {
+    fun afterCommit(action: () -> Unit)
+    fun afterRollback(action: () -> Unit)
+    fun rollback(): Nothing
+    fun transaction(body: SqkonTransactionScope.() -> Unit) // nested
+}
+```
+
+- `afterCommit { }` / `afterRollback { }` — run a side effect once the **outermost**
+  transaction settles (e.g. fire an analytics event only if the write stuck).
+- `rollback()` — abort and discard the work. In `transaction { }` it returns
+  silently; in `transactionWithResult { }` it throws `SqkonRollbackException`
+  (there is no value to return). Either way the database transaction — and any
+  enclosing one (there are no savepoints) — rolls back.
+- `transaction { }` — a nested block; an inner `rollback()` rolls back the whole
+  enclosing transaction.
+
+```kotlin
+merchants.transaction {
+    merchants.upsert(merchant.id, merchant)
+    if (!merchant.isValid) rollback() // nothing is written
+    afterCommit { analytics.track("merchant_saved") }
+}
+```
+
+## Upgrading from 1.x
+
+`transaction { }` and `transactionWithResult { }` calls are **source-compatible** —
+they resolve to the new extension functions unchanged. You only need to act if:
+
+| 1.x | 2.0 |
+|-----|-----|
+| `val t: Transacter = store` (treating a store as a SQLDelight `Transacter`) | removed — call `store.transaction { … }` directly |
+| `import app.cash.sqldelight.TransactionCallbacks` as the block receiver type | `SqkonTransactionScope` (usually implicit — just drop the import) |
+| SQLDelight `Transacter` members beyond `afterCommit` / `afterRollback` / `rollback` / nested `transaction` | rework against `SqkonTransactionScope` |
+| `transactionWithResult { rollback() }` returned the rollback value | now throws `SqkonRollbackException` — catch it if you relied on the return |
 
 ## What's already atomic
 
@@ -102,7 +151,6 @@ operation onto a background thread yourself.
 
 - [Reactive flows]({{ '/guides/flow/' | relative_url }}) — when emissions fire
   relative to commits.
-- Upstream API: SQLDelight
-  [Transacter](https://cashapp.github.io/sqldelight/2.0.0/jvm_sqlite/transactions/).
-- Source: `library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/SqkonTransacter.kt`,
-  `library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt`.
+- Source: `library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt`,
+  `library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt`,
+  `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt`.

--- a/docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md
+++ b/docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md
@@ -35,7 +35,7 @@ Sqkon is migrating off SQLDelight in seven phases. Phases 0–4 are merged. Phas
 **Modified files:**
 - `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt` — replace the `Transacter.Transaction.parentTransactionHash()` extension with an `internal fun currentParentTransactionHash(): Int` that lives inside the transacter. Keep the `transaction`/`transactionWithResult` overrides + `trxMap`.
 - `library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt` — drop `: Transacter by transacter`; drop the two sqldelight imports; add `internal open fun transaction(...)` / `internal open fun <R> transactionWithResult(...)` members; change `internal fun TransactionCallbacks.updateWriteAt()` → `internal fun SqkonTransactionScope.updateWriteAt()` (compute the dedup hash via `transacter.currentParentTransactionHash()`).
-- `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt` — retarget the two assertions onto `transacter.currentParentTransactionHash()`.
+- `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt` — retarget the two assertions onto `transacter.currentParentTransactionHash()`.
 - `library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt` — **add** two `transactionWithResult` tests (commit-returns-value, rollback-throws-and-aborts). Existing 5 tests are unchanged and are the gate.
 - `README.MD` — add a short "Transactions" usage section (none exists today).
 
@@ -188,7 +188,7 @@ Expected: BUILD SUCCESSFUL. (`KeyValueStorage.kt` still references the old exten
 
 - [ ] **Step 3: Update the internal parent-hash test**
 
-In `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt` replace each `with(transacter) { sqlDriver.currentTransaction()!!.parentTransactionHash() }` (and the `current.parentTransactionHash()` form) with `transacter.currentParentTransactionHash()`. Final form:
+In `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt` replace each `with(transacter) { sqlDriver.currentTransaction()!!.parentTransactionHash() }` (and the `current.parentTransactionHash()` form) with `transacter.currentParentTransactionHash()`. Final form:
 
 ```kotlin
     @Test
@@ -222,7 +222,7 @@ In `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParen
 
 ```bash
 git add library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt \
-        library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt
+        library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt
 git commit -m "refactor: move parent-transaction hash into SqkonTransacter (MOB-3292)"
 ```
 
@@ -411,7 +411,7 @@ Run:
 ```bash
 ./gradlew :library:jvmTest --tests "*.KeyValueStorageTransactionTest" \
   --tests "*.KeyValueStorageTest" \
-  --tests "*.SqkonTracerParentTest" \
+  --tests "*.SqkonTransacterParentTest" \
   --tests "*.SqkonTransactionForwardingTest"
 ```
 Expected: all PASS. The 5 pre-existing `KeyValueStorageTransactionTest` cases + `externalTransaction` + `updateWriteAtOnlyRunsOncePerTransaction` prove the refactor preserved behavior; the 2 new cases prove the result path.

--- a/docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md
+++ b/docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md
@@ -1,0 +1,555 @@
+# Sqkon Phase 5 — Hide SQLDelight `Transacter` behind `SqkonTransactionScope` (`feat!:` 2.0)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Linear ticket:** [MOB-3292](https://linear.app/mercury/issue/MOB-3292/sqkon-migration-phase-5-feat-hide-transacter-behind)
+**Branch:** new worktree `worktree-phase-5` off `main` (Phase 4 merged as `a4142b7`).
+**Final plan location:** On approval, move this file to `docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md` (matches the Phase 1/4 convention).
+
+**Goal:** Remove `app.cash.sqldelight.Transacter` and `app.cash.sqldelight.TransactionCallbacks` from Sqkon's **public** API. Replace `KeyValueStorage : Transacter by transacter` with a public, Sqkon-owned `SqkonTransactionScope` sealed interface plus `transaction { }` / `transactionWithResult { }` extension functions. This is the migration's **only breaking change** — release-please cuts **2.0** from the `feat!:` prefix.
+
+**Architecture:** Add a public `sealed interface SqkonTransactionScope` (afterCommit / afterRollback / rollback / nested transaction) in `com.mercury.sqkon.db`. Two internal sqldelight-backed wrapper classes (one for the `Unit` path, one for the result path) adapt SQLDelight's lambda receivers to the scope; they live in the **same package** as the sealed interface (Kotlin requires sealed implementations to share the interface's package + module). Public access is via top-level extension functions on `KeyValueStorage<T>`; `internal open fun transaction`/`transactionWithResult` **members** keep the existing in-class call sites (`insert`/`update`/`delete`/…) compiling and provide the open-subclassing seam the ticket asks for. `SqkonTransacter` stays `TransacterImpl(SqlDriver)`-backed — the driver swap to `SqkonDriver` is **Phase 6 (MOB-3293)**, not this phase.
+
+**Tech Stack:** Kotlin Multiplatform (commonMain, jvmMain, androidMain, iosMain scaffold). `app.cash.sqldelight` (internal-only after this phase). `kotlin.test` + `kotlinx-coroutines-test` (`runTest`) + Turbine.
+
+---
+
+## Context
+
+Sqkon is migrating off SQLDelight in seven phases. Phases 0–4 are merged. Phase 4 (MOB-3291) hand-rolled the schema; the **query** path was hand-rolled behind the internal `SqkonDriver` abstraction in Phase 3. The remaining public coupling to SQLDelight is the **transaction** surface:
+
+`KeyValueStorage<T>` is declared `: Transacter by transacter`, so callers can use a store *as* a `app.cash.sqldelight.Transacter` and the `transaction { }` lambda receiver is SQLDelight's `TransactionCallbacks`/`TransactionWithoutReturn`. The write-batching helper is `internal fun TransactionCallbacks.updateWriteAt()`. Phase 5 severs this so the public API names only Sqkon types. This unblocks **Phase 6 (MOB-3293)**, which replaces `AndroidxSqliteDriver` with a native `SqkonDriver` and flips `SqkonTransacter` off `TransacterImpl` — at which point the sqldelight imports added here as `internal` are deleted.
+
+**Why it's breaking:** removing `: Transacter by transacter` and `TransactionCallbacks` from a public-visible signature is source-incompatible for any consumer that holds `val s: Transacter = store` or imports `TransactionCallbacks`. Hence `feat!:` → 2.0.
+
+**Pre-merge action item (out-of-repo, do NOT block plan execution):** inventory internal Mercury consumers of `Transacter` / `TransactionCallbacks` from sqkon. In-repo there are zero non-test external usages (see "Existing Code" below); coordinate any downstream `val x: Transacter = ...` before merging the PR.
+
+---
+
+## File Structure
+
+**New files (all `com.mercury.sqkon.db`, commonMain):**
+- `library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt` — public `sealed interface SqkonTransactionScope` + public `class SqkonRollbackException internal constructor(...)`.
+- `library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt` — public `transaction` / `transactionWithResult` extension functions **and** the two `internal` sqldelight-backed scope implementations (same package as the sealed interface).
+
+**Modified files:**
+- `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt` — replace the `Transacter.Transaction.parentTransactionHash()` extension with an `internal fun currentParentTransactionHash(): Int` that lives inside the transacter. Keep the `transaction`/`transactionWithResult` overrides + `trxMap`.
+- `library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt` — drop `: Transacter by transacter`; drop the two sqldelight imports; add `internal open fun transaction(...)` / `internal open fun <R> transactionWithResult(...)` members; change `internal fun TransactionCallbacks.updateWriteAt()` → `internal fun SqkonTransactionScope.updateWriteAt()` (compute the dedup hash via `transacter.currentParentTransactionHash()`).
+- `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt` — retarget the two assertions onto `transacter.currentParentTransactionHash()`.
+- `library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt` — **add** two `transactionWithResult` tests (commit-returns-value, rollback-throws-and-aborts). Existing 5 tests are unchanged and are the gate.
+- `README.MD` — add a short "Transactions" usage section (none exists today).
+
+**Untouched (verified):** `SqkonTransaction` (internal abstract, Phase-3 scaffold) and `SqlDelightSqkonTransaction` + `SqkonTransactionForwardingTest` — these are parallel internal scaffolding, **not** referenced by production transaction code, and still compile. `EntityQueries`/`MetadataQueries` keep `: TransacterImpl(...)` (internal query layer; reconciled in Phase 6/7). `KeysetQueryPagingSource`/`OffsetQueryPagingSource` keep their internal `transacter: Transacter` constructor params (not in any public-visible signature; the public methods return `PagingSource<…>`). The `keyValueStorage(...)` factory is unchanged.
+
+---
+
+## Existing Code to Reuse (verified file:line)
+
+- **`KeyValueStorage.kt`** `library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt`
+  - `:48` class header `... ) : Transacter by transacter {` — drop the supertype.
+  - `:47` `private val transacter: SqkonTransacter` — **keep private**; members below use it.
+  - `:59,93,108,127,142,159,415,429,444,462` methods use `= transaction { … }` then `updateWriteAt()` — these call sites stay verbatim; only the lambda **receiver type** changes (sqldelight `TransactionWithoutReturn` → `SqkonTransactionScope`), which is source-compatible because the bodies only call `entityQueries.*`, sibling methods, `updateWriteAt()`, and `return@transaction`.
+  - `:489` `else -> return@transaction` — label still resolves to the `transaction` member call.
+  - `:542-551` `updateReadAt` uses `metadataQueries.transaction { … }` — **unchanged** (different object; sqldelight `TransacterImpl`).
+  - `:553` `private val updateWriteHashes = mutableSetOf<Int>()` — reuse.
+  - `:559-573` `internal fun TransactionCallbacks.updateWriteAt()` — convert receiver to `SqkonTransactionScope`; replace `with(transacter){ entityQueries.sqlDriver.currentTransaction()!!.parentTransactionHash() }` with `transacter.currentParentTransactionHash()`.
+  - `:604-627` `inline fun <reified T> keyValueStorage(...)` — unchanged.
+- **`SqkonTransacter.kt`** `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt`
+  - `:15` `open class SqkonTransacter(driver: SqlDriver) : TransacterImpl(driver)` — keep (driver swap is Phase 6).
+  - `:18` `protected val trxMap = mutableMapOf<Transacter.Transaction, Transacter.Transaction?>()` — keep (key stays the sqldelight transaction; an internal detail until Phase 6).
+  - `:20-23` `fun Transacter.Transaction.parentTransactionHash(): Int` — **replace** with a private helper + `currentParentTransactionHash()` (see Task 2).
+  - `:25-61` `transaction` / `transactionWithResult` overrides — keep verbatim (they record `trxMap` and are what the scope wrappers call for nesting).
+- **Gate test:** `library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt` — 5 tests pin behavior: silent rollback (`:30`), nested rollback rolls back enclosing (`:40`), `afterCommit` visible after commit (`:55`), `afterCommit` skipped on rollback (`:71`), nested `afterCommit` fires once at outermost commit (`:87`). **Must stay green unchanged.**
+- **Dedup test:** `KeyValueStorageTest.kt:679` `updateWriteAtOnlyRunsOncePerTransaction` — `transaction { with(testObjectStorage) { updateWriteAt(); updateWriteAt() } }` exercises `SqkonTransactionScope.updateWriteAt()`; must stay green.
+- **External-tx test:** `KeyValueStorageTest.kt:663` `externalTransaction` — `store.transaction { deleteAll(); insertAll(...) }`; resolves to the new public extension.
+
+---
+
+## SQLDelight API facts (relied on)
+
+- `interface TransactionCallbacks { fun afterCommit(fn: () -> Unit); fun afterRollback(fn: () -> Unit) }`
+- `interface TransactionWithoutReturn : TransactionCallbacks { fun rollback(): Nothing; fun transaction(noEnclosing: Boolean = false, body: TransactionWithoutReturn.() -> Unit) }`
+- `interface TransactionWithReturn<R> : TransactionCallbacks { fun rollback(returnValue: R): Nothing; fun transaction(...); fun <R> transactionWithResult(...): R }`
+- `TransactionWithoutReturn.rollback()` throws SQLDelight's internal `RollbackException` (caught by the transacter → caller sees a **silent** return). Any *other* exception escaping a transaction body also rolls the DB back, then propagates to the caller. The result-path `rollback()` exploits this: it throws `SqkonRollbackException` (our type, since SQLDelight's is internal), the DB rolls back, the exception reaches the caller.
+
+---
+
+## Critical Invariants
+
+1. **`KeyValueStorageTransactionTest` (5 tests) stays green unchanged.** It is the behavioral gate for this refactor.
+2. **Member-over-extension resolution.** The `internal open fun transaction`/`transactionWithResult` **members** and the same-named public **extension functions** coexist. Kotlin always resolves a member over an extension when both apply, so: in-module callers (`insert`/`update`/…) and the extension bodies hit the member; out-of-module callers (which can't see the `internal` member) hit the extension. No recursion, identical behavior.
+3. **Nested transactions must route through `SqkonTransacter`.** `SqkonTransactionScope.transaction { }` calls `transacter.transaction(noEnclosing = false) { … }` (NOT the sqldelight receiver's own `transaction`) so `trxMap` records the parent→child link. This is what makes `currentParentTransactionHash()` collapse nested inserts to one `updateWriteAt` afterCommit (the dedup the tests pin).
+4. **Rollback semantics:** `transaction { rollback() }` → silent (SQLDelight). `transactionWithResult { rollback() }` → throws `SqkonRollbackException` (no value to return). Both abort the DB transaction.
+5. **`sealed` placement:** `SqkonTransactionScope` is `sealed`; its only implementations are `internal` classes in the **same package** (`com.mercury.sqkon.db`). This is a deliberate, documented deviation from the ticket's prose ("internal `SqkonTransaction` implements it") — `SqkonTransaction` is in `…​.internal`, and Kotlin forbids a sealed type's implementations from another package.
+6. **`SqkonTransacter` stays `TransacterImpl`-backed.** Driver swap + dropping `TransacterImpl` is Phase 6. Do not change its constructor or supertype here.
+
+---
+
+## Tasks
+
+### Task 1: Add the public `SqkonTransactionScope` interface
+
+**Files:** Create `library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt`
+
+- [ ] **Step 1: Create the file**
+
+```kotlin
+package com.mercury.sqkon.db
+
+/**
+ * Sqkon-owned transaction scope, the receiver of [transaction] / [transactionWithResult].
+ *
+ * Replaces direct exposure of SQLDelight's `Transacter` / `TransactionCallbacks`. `sealed` — only
+ * Sqkon provides implementations; callers must not implement it.
+ */
+sealed interface SqkonTransactionScope {
+
+    /** Run [action] after the outermost enclosing transaction commits. */
+    fun afterCommit(action: () -> Unit)
+
+    /** Run [action] after the transaction rolls back. */
+    fun afterRollback(action: () -> Unit)
+
+    /**
+     * Abort the transaction.
+     *
+     * In [transaction] this returns silently to the caller (the work is discarded). In
+     * [transactionWithResult] there is no value to return, so it throws [SqkonRollbackException].
+     * In either case the database transaction (and any enclosing one — there are no savepoints) is
+     * rolled back.
+     */
+    fun rollback(): Nothing
+
+    /**
+     * Run [body] in a nested transaction. A nested rollback rolls back the enclosing transaction
+     * too (no savepoint semantics).
+     */
+    fun transaction(body: SqkonTransactionScope.() -> Unit)
+}
+
+/**
+ * Thrown out of [transactionWithResult] when [SqkonTransactionScope.rollback] is called: a
+ * result-returning transaction has no value to hand back on rollback, so it aborts by throwing.
+ */
+class SqkonRollbackException internal constructor() :
+    RuntimeException("Sqkon transaction rolled back")
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :library:compileCommonMainKotlinMetadata`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt
+git commit -m "feat(arch): add public SqkonTransactionScope interface (MOB-3292)"
+```
+
+---
+
+### Task 2: Consolidate the parent-transaction hash inside `SqkonTransacter`
+
+**Files:** Modify `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt`
+
+- [ ] **Step 1: Replace the `parentTransactionHash()` extension with an internal member helper**
+
+Replace lines 20-23:
+```kotlin
+    fun Transacter.Transaction.parentTransactionHash(): Int {
+        // Walk up the chain. Top level: hash of self.
+        return trxMap[this]?.parentTransactionHash() ?: this.hashCode()
+    }
+```
+With:
+```kotlin
+    /**
+     * Stable identity hash of the *outermost* transaction enclosing the one currently running on
+     * [driver]. Used to dedup per-transaction side effects (e.g. the metadata write_at touch) so a
+     * batch of nested writes only schedules one afterCommit. Must be called inside a transaction.
+     */
+    internal fun currentParentTransactionHash(): Int {
+        val current = driver.currentTransaction()
+            ?: error("currentParentTransactionHash() called outside a transaction")
+        return current.outermostHash()
+    }
+
+    private fun Transacter.Transaction.outermostHash(): Int =
+        trxMap[this]?.outermostHash() ?: this.hashCode()
+```
+
+(Keep the imports, `trxMap`, and both `transaction` / `transactionWithResult` overrides exactly as-is. `driver` is `TransacterImpl`'s protected field; `currentTransaction()` is on `SqlDriver`.)
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :library:compileCommonMainKotlinMetadata`
+Expected: BUILD SUCCESSFUL. (`KeyValueStorage.kt` still references the old extension — that's fixed in Task 3; if you compile metadata only, it fails there. Run the full compile after Task 3.)
+
+- [ ] **Step 3: Update the internal parent-hash test**
+
+In `library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt` replace each `with(transacter) { sqlDriver.currentTransaction()!!.parentTransactionHash() }` (and the `current.parentTransactionHash()` form) with `transacter.currentParentTransactionHash()`. Final form:
+
+```kotlin
+    @Test
+    fun nested_transaction_parentHash_equals_outer_hash() {
+        var outerHash = 0
+        var innerParentHash = 0
+        transacter.transaction {
+            outerHash = transacter.currentParentTransactionHash()
+            transacter.transaction {
+                innerParentHash = transacter.currentParentTransactionHash()
+            }
+        }
+        assertEquals(outerHash, innerParentHash)
+    }
+
+    @Test
+    fun top_level_transaction_parentHash_equals_self() {
+        var selfHash = 0
+        var parentHash = 0
+        transacter.transaction {
+            selfHash = sqlDriver.currentTransaction()!!.hashCode()
+            parentHash = transacter.currentParentTransactionHash()
+        }
+        assertEquals(selfHash, parentHash)
+    }
+```
+
+(Remove the now-unused `import` of nothing extra; `sqlDriver` is already the test field.)
+
+- [ ] **Step 4: Commit** (after Task 3 compiles — or commit now and let the metadata-compile gap close in Task 3; prefer committing together with Task 3 if executing inline.)
+
+```bash
+git add library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt \
+        library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTracerParentTest.kt
+git commit -m "refactor: move parent-transaction hash into SqkonTransacter (MOB-3292)"
+```
+
+---
+
+### Task 3: Add scope implementations + extension functions; rewire `KeyValueStorage`
+
+**Files:**
+- Create `library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt`
+- Modify `library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt`
+
+- [ ] **Step 1: Create `Transactions.kt`**
+
+```kotlin
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.TransactionWithReturn
+import app.cash.sqldelight.TransactionWithoutReturn
+import com.mercury.sqkon.db.internal.SqkonTransacter
+
+/**
+ * Run [body] in a database transaction. Replaces the SQLDelight `Transacter.transaction { }` that
+ * [KeyValueStorage] used to inherit. Calling [SqkonTransactionScope.rollback] discards the work and
+ * returns silently.
+ */
+fun <T : Any> KeyValueStorage<T>.transaction(body: SqkonTransactionScope.() -> Unit): Unit =
+    transaction(body) // resolves to the internal member (members win over extensions)
+
+/**
+ * Run [body] in a database transaction and return its value. Calling [SqkonTransactionScope.rollback]
+ * aborts the transaction and throws [SqkonRollbackException] (there is no value to return).
+ */
+fun <T : Any, R> KeyValueStorage<T>.transactionWithResult(body: SqkonTransactionScope.() -> R): R =
+    transactionWithResult(body) // resolves to the internal member
+
+/** Scope backing the `Unit` transaction path. Wraps SQLDelight's [TransactionWithoutReturn]. */
+internal class SqlDelightTransactionScope(
+    private val tx: TransactionWithoutReturn,
+    private val transacter: SqkonTransacter,
+) : SqkonTransactionScope {
+    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
+    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
+    override fun rollback(): Nothing = tx.rollback()
+    override fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        // Route nesting through SqkonTransacter so trxMap records the parent link.
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+}
+
+/** Scope backing the result path. Wraps SQLDelight's [TransactionWithReturn]; rollback throws. */
+internal class SqlDelightResultTransactionScope<R>(
+    @Suppress("unused") private val tx: TransactionWithReturn<R>,
+    private val transacter: SqkonTransacter,
+) : SqkonTransactionScope {
+    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
+    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
+    override fun rollback(): Nothing = throw SqkonRollbackException()
+    override fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Edit `KeyValueStorage.kt` — drop the sqldelight imports**
+
+Remove these two import lines (4-5):
+```kotlin
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransactionCallbacks
+```
+(Keep `import com.mercury.sqkon.db.internal.SqkonTransacter`.)
+
+- [ ] **Step 3: Edit the class header (line 48) — drop the delegate**
+
+Change:
+```kotlin
+    private val transacter: SqkonTransacter,
+) : Transacter by transacter {
+```
+To:
+```kotlin
+    private val transacter: SqkonTransacter,
+) {
+```
+
+- [ ] **Step 4: Add the `internal open` transaction members**
+
+Insert directly after the class header `{` (before `insert`, around line 49). These give the in-class call sites their `transaction { }` target and provide the open seam for internal subclasses:
+
+```kotlin
+    /**
+     * Internal transaction seam. The public surface is the [transaction] extension function;
+     * this `open` member exists so internal subclasses can wrap transaction behavior (extensions
+     * can't be overridden) and so in-class callers resolve here.
+     */
+    internal open fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+
+    internal open fun <R> transactionWithResult(body: SqkonTransactionScope.() -> R): R =
+        transacter.transactionWithResult(noEnclosing = false) {
+            SqlDelightResultTransactionScope(this, transacter).body()
+        }
+```
+
+- [ ] **Step 5: Convert `updateWriteAt()` to the new receiver (lines 559-573)**
+
+Change the signature + hash computation:
+```kotlin
+    internal fun SqkonTransactionScope.updateWriteAt() {
+        val requestHash = transacter.currentParentTransactionHash()
+        if (requestHash in updateWriteHashes) return
+        updateWriteHashes.add(requestHash)
+        afterCommit {
+            updateWriteHashes.remove(requestHash)
+            scope.launch(writeDispatcher) {
+                metadataQueries.transaction {
+                    metadataQueries.upsertWrite(entityName, Clock.System.now())
+                }
+            }
+        }
+    }
+```
+(Only the receiver type and the `requestHash` line change; the `afterCommit { … }` body is identical. `afterCommit` now resolves to `SqkonTransactionScope.afterCommit`.)
+
+- [ ] **Step 6: Verify commonMain + Android compile**
+
+Run: `./gradlew :library:compileCommonMainKotlinMetadata :library:compileKotlinJvm :library:compileDebugKotlinAndroid`
+Expected: BUILD SUCCESSFUL. If you see "overload resolution ambiguity" or unexpected recursion on `transaction`, confirm the members are `internal` (not `public`) and the extensions are top-level in `Transactions.kt`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt \
+        library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+git commit -m "feat!: hide sqldelight transacter behind SqkonTransactionScope extension functions (MOB-3292)"
+```
+
+---
+
+### Task 4: Test the new public API (commit + rollback)
+
+**Files:** Modify `library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt`
+
+- [ ] **Step 1: Add imports** (top of file)
+
+```kotlin
+import kotlin.test.assertFailsWith
+```
+
+- [ ] **Step 2: Add two tests inside the class** (before the `private companion object`)
+
+```kotlin
+    @Test
+    fun transactionWithResult_commitReturnsValue() = runTest {
+        val inserted = storage.transactionWithResult {
+            storage.insert("twr", TestObject())
+            42
+        }
+        assertEquals(42, inserted)
+        assertEquals(1, storage.count().first())
+    }
+
+    @Test
+    fun transactionWithResult_rollbackThrowsAndAborts() = runTest {
+        assertFailsWith<SqkonRollbackException> {
+            storage.transactionWithResult<TestObject, Int> {
+                storage.insert("twr", TestObject())
+                rollback()
+            }
+        }
+        // DB rolled back: the insert is gone.
+        assertEquals(0, storage.count().first())
+    }
+```
+
+- [ ] **Step 3: Run the transaction + storage tests**
+
+Run:
+```bash
+./gradlew :library:jvmTest --tests "*.KeyValueStorageTransactionTest" \
+  --tests "*.KeyValueStorageTest" \
+  --tests "*.SqkonTracerParentTest" \
+  --tests "*.SqkonTransactionForwardingTest"
+```
+Expected: all PASS. The 5 pre-existing `KeyValueStorageTransactionTest` cases + `externalTransaction` + `updateWriteAtOnlyRunsOncePerTransaction` prove the refactor preserved behavior; the 2 new cases prove the result path.
+
+If `updateWriteAtOnlyRunsOncePerTransaction` fails (more than one metadata emission): nesting isn't routing through `SqkonTransacter` — re-check Invariant 3 (scope `transaction` must call `transacter.transaction`, not `tx.transaction`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
+git commit -m "test: cover SqkonTransactionScope transactionWithResult commit + rollback (MOB-3292)"
+```
+
+---
+
+### Task 5: Document the new transaction API in the README
+
+**Files:** Modify `README.MD`
+
+- [ ] **Step 1: Add a "Transactions" section** (after the existing usage examples; pick a sensible heading level matching neighbors)
+
+````markdown
+### Transactions
+
+Group multiple writes into one atomic transaction with the `transaction { }` extension. Inserts,
+updates and deletes inside the block commit together (or roll back together):
+
+```kotlin
+store.transaction {
+    store.deleteAll()
+    store.insertAll(newItems)
+}
+```
+
+`rollback()` aborts the transaction and discards the work:
+
+```kotlin
+store.transaction {
+    store.insert(key, value)
+    if (shouldAbort) rollback() // nothing is written; returns silently
+}
+```
+
+Use `afterCommit { }` / `afterRollback { }` to react once the outermost transaction settles, and
+`transactionWithResult { }` when you need a return value (here `rollback()` throws
+`SqkonRollbackException`, since there is no value to return):
+
+```kotlin
+val count: Int = store.transactionWithResult {
+    store.insertAll(items)
+    afterCommit { log("committed") }
+    items.size
+}
+```
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.MD
+git commit -m "docs: document SqkonTransactionScope transaction API (MOB-3292)"
+```
+
+---
+
+### Task 6: Final verification, push, PR
+
+- [ ] **Step 1: Full clean test run**
+
+```bash
+./gradlew clean
+./gradlew :library:jvmTest
+```
+Expected: BUILD SUCCESSFUL, all tests pass.
+
+- [ ] **Step 2: Confirm the public API no longer names the sqldelight transaction types**
+
+```bash
+grep -rn 'app.cash.sqldelight.Transacter\|TransactionCallbacks' library/src/commonMain
+```
+Expected: zero hits in `KeyValueStorage.kt`. Remaining hits, if any, are confined to `internal` classes (`SqkonTransacter`, the `Transactions.kt` scope wrappers, `EntityQueries`/`MetadataQueries`, paging sources) — acceptable for Phase 5; the wrappers/queries are reconciled in Phase 6.
+
+- [ ] **Step 3: Android compile sanity** (instrumented tests run in CI per CLAUDE.md)
+
+```bash
+./gradlew :library:compileDebugKotlinAndroid
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin worktree-phase-5
+gh pr create \
+  --title "feat!: hide sqldelight transacter behind SqkonTransactionScope (MOB-3292)" \
+  --body "$(cat <<'EOF'
+## Summary
+Phase 5 of the SQLDelight migration (MOB-3292). Removes `app.cash.sqldelight.Transacter` and
+`TransactionCallbacks` from Sqkon's public API:
+- `KeyValueStorage` no longer `: Transacter by transacter`.
+- New public `sealed interface SqkonTransactionScope` + `transaction { }` / `transactionWithResult { }`
+  extension functions; `rollback()`, `afterCommit`, `afterRollback`, nested transactions.
+- `transactionWithResult { rollback() }` throws `SqkonRollbackException` (no value to return);
+  `transaction { rollback() }` returns silently (unchanged SQLDelight behavior).
+- Internal machinery (`SqkonTransacter`) stays SQLDelight-backed — the driver swap is Phase 6.
+
+**BREAKING (2.0):** consumers holding `val x: Transacter = store` or importing `TransactionCallbacks`
+must move to the `transaction { }` extension. `release-please` cuts 2.0 from the `feat!:` prefix.
+
+## Test Plan
+- [ ] `./gradlew :library:jvmTest` green (gate: `KeyValueStorageTransactionTest` unchanged + 2 new
+      `transactionWithResult` cases; `updateWriteAtOnlyRunsOncePerTransaction` proves the nested
+      dedup still works).
+- [ ] CI `run-android-tests` green.
+EOF
+)"
+```
+
+- [ ] **Step 5:** Finish via **superpowers:finishing-a-development-branch** (verify tests → present options). Per CLAUDE.md, do **not** create a GitHub release manually — release-please handles the 2.0 cut once merged.
+
+---
+
+## Verification (end-to-end)
+
+1. **Behavior preserved** — `KeyValueStorageTransactionTest` (5 original cases) + `KeyValueStorageTest.externalTransaction` + `updateWriteAtOnlyRunsOncePerTransaction` pass unchanged.
+2. **New API works** — `transactionWithResult` returns its value on commit and throws `SqkonRollbackException` (DB aborted) on `rollback()`.
+3. **Public API clean** — `grep` shows no `Transacter`/`TransactionCallbacks` in `KeyValueStorage.kt`; the only `commonMain` references are `internal`.
+4. **Multiplatform compiles** — `compileKotlinJvm` + `compileDebugKotlinAndroid` (+ metadata) succeed; iOS targets compile in CI.
+5. **CI green** — `jvm-tests`, `Compile iOS targets`, `run-android-tests`.
+6. **2.0 cut** — merged `feat!:` commit makes release-please open a `release: 2.0.0` PR.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Member/extension ambiguity or accidental recursion on `transaction` | Members always win over same-signature extensions in Kotlin. Members are `internal`, extensions are top-level public. Verified by Task 3 Step 6 compile + Task 4 tests. |
+| Nested writes schedule multiple `updateWriteAt` afterCommits | Scope `transaction { }` routes nesting through `SqkonTransacter.transaction` so `trxMap` records parents; `currentParentTransactionHash()` collapses them. Pinned by `updateWriteAtOnlyRunsOncePerTransaction`. |
+| `sealed` + impl package rule | Scope impls live in `com.mercury.sqkon.db` (same package as the interface), `internal`. Documented deviation from ticket prose. |
+| `transactionWithResult` rollback divergence from SQLDelight (`rollback(value)` returns; ours throws) | Intentional, per maintainer: a `rollback(): Nothing` has no value to return, so it throws `SqkonRollbackException`. Documented in KDoc + README. |
+| Downstream Mercury consumers hold `Transacter` | Out-of-repo pre-merge inventory (ticket action item). In-repo: zero non-test external usages. |
+| Transitive `Transacter` leak via public `SqkonTransacter : TransacterImpl` in the `keyValueStorage(...)` factory default | Out of Phase 5 scope; resolved in Phase 6 (MOB-3293) when `SqkonTransacter` drops `TransacterImpl` for `SqkonDriver`. Ticket exit criteria targets the explicit `KeyValueStorage` surface, which this phase clears. |

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -1,8 +1,6 @@
 package com.mercury.sqkon.db
 
 import androidx.paging.PagingSource
-import app.cash.sqldelight.Transacter
-import app.cash.sqldelight.TransactionCallbacks
 import com.mercury.sqkon.db.internal.asFlow
 import com.mercury.sqkon.db.internal.mapToList
 import com.mercury.sqkon.db.internal.mapToOne
@@ -45,7 +43,23 @@ open class KeyValueStorage<T : Any>(
     protected val readDispatcher: CoroutineDispatcher,
     protected val writeDispatcher: CoroutineDispatcher,
     private val transacter: SqkonTransacter,
-) : Transacter by transacter {
+) {
+
+    /**
+     * Internal transaction seam. The public surface is the [transaction] extension function;
+     * this `open` member exists so internal subclasses can wrap transaction behavior (extensions
+     * can't be overridden) and so in-class callers resolve here.
+     */
+    internal open fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+
+    internal open fun <R> transactionWithResult(body: SqkonTransactionScope.() -> R): R =
+        transacter.transactionWithResult(noEnclosing = false) {
+            SqlDelightResultTransactionScope(this, transacter).body()
+        }
 
     /**
      * Insert a row.
@@ -556,10 +570,8 @@ open class KeyValueStorage<T : Any>(
      * Will run after the transaction is committed. This way inside of multiple inserts we only
      * update the write_at once.
      */
-    internal fun TransactionCallbacks.updateWriteAt() {
-        val requestHash = with(transacter) {
-            entityQueries.sqlDriver.currentTransaction()!!.parentTransactionHash()
-        }
+    internal fun SqkonTransactionScope.updateWriteAt() {
+        val requestHash = transacter.currentParentTransactionHash()
         if (requestHash in updateWriteHashes) return
         updateWriteHashes.add(requestHash)
         afterCommit {

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -46,19 +46,24 @@ open class KeyValueStorage<T : Any>(
 ) {
 
     /**
-     * Internal transaction seam. The public surface is the [transaction] extension function;
-     * this `open` member exists so internal subclasses can wrap transaction behavior (extensions
-     * can't be overridden) and so in-class callers resolve here.
+     * Internal transaction seam. The public surface is the [transaction] / [transactionWithResult]
+     * extension functions; these `open` members exist so internal subclasses can wrap transaction
+     * behavior (extensions can't be overridden) and so in-class callers (`insert`, `delete`, …) have
+     * a target.
      */
-    internal open fun transaction(body: SqkonTransactionScope.() -> Unit) {
-        transacter.transaction(noEnclosing = false) {
-            SqlDelightTransactionScope(this, transacter).body()
+    internal open fun runTransaction(body: SqkonTransactionScope.() -> Unit) {
+        try {
+            transacter.transaction(noEnclosing = false) {
+                SqlDelightTransactionScope(this, transacter).body()
+            }
+        } catch (_: SqkonRollbackException) {
+            // rollback() in a Unit transaction aborts silently; the DB transaction already rolled back.
         }
     }
 
-    internal open fun <R> transactionWithResult(body: SqkonTransactionScope.() -> R): R =
+    internal open fun <R> runTransactionWithResult(body: SqkonTransactionScope.() -> R): R =
         transacter.transactionWithResult(noEnclosing = false) {
-            SqlDelightResultTransactionScope(this, transacter).body()
+            SqlDelightTransactionScope(this, transacter).body()
         }
 
     /**
@@ -74,7 +79,7 @@ open class KeyValueStorage<T : Any>(
         key: String, value: T,
         ignoreIfExists: Boolean = false,
         expiresAt: Instant? = null,
-    ) = transaction {
+    ) = runTransaction {
         val now = nowMillis()
         val entity = Entity(
             entity_name = entityName,
@@ -104,7 +109,7 @@ open class KeyValueStorage<T : Any>(
         values: Map<String, T>,
         ignoreIfExists: Boolean = false,
         expiresAt: Instant? = null,
-    ) = transaction {
+    ) = runTransaction {
         values.forEach { (key, value) -> insert(key, value, ignoreIfExists, expiresAt) }
     }
 
@@ -119,7 +124,7 @@ open class KeyValueStorage<T : Any>(
      * @see insert
      * @see upsert
      */
-    fun update(key: String, value: T, expiresAt: Instant? = null) = transaction {
+    fun update(key: String, value: T, expiresAt: Instant? = null) = runTransaction {
         entityQueries.updateEntity(
             entityName = entityName,
             entityKey = key,
@@ -140,7 +145,7 @@ open class KeyValueStorage<T : Any>(
      */
     fun updateAll(
         values: Map<String, T>, expiresAt: Instant? = null,
-    ) = transaction {
+    ) = runTransaction {
         values.forEach { (key, value) -> update(key, value, expiresAt) }
     }
 
@@ -155,7 +160,7 @@ open class KeyValueStorage<T : Any>(
      */
     fun upsert(
         key: String, value: T, expiresAt: Instant? = null,
-    ) = transaction {
+    ) = runTransaction {
         update(key, value, expiresAt = expiresAt)
         insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
     }
@@ -173,7 +178,7 @@ open class KeyValueStorage<T : Any>(
     fun upsertAll(
         values: Map<String, T>,
         expiresAt: Instant? = null,
-    ) = transaction {
+    ) = runTransaction {
         values.forEach { (key, value) ->
             update(key, value, expiresAt = expiresAt)
             insert(key, value, ignoreIfExists = true, expiresAt = expiresAt)
@@ -426,7 +431,7 @@ open class KeyValueStorage<T : Any>(
      * @see delete
      * @see deleteAll
      */
-    fun deleteByKeys(vararg key: String) = transaction {
+    fun deleteByKeys(vararg key: String) = runTransaction {
         entityQueries.delete(entityName, entityKeys = key.toSet())
         updateWriteAt()
     }
@@ -440,7 +445,7 @@ open class KeyValueStorage<T : Any>(
      * @see deleteAll
      * @see deleteByKey
      */
-    fun delete(where: Where<T>? = null) = transaction {
+    fun delete(where: Where<T>? = null) = runTransaction {
         entityQueries.delete(entityName, where = where)
         updateWriteAt()
     }
@@ -455,7 +460,7 @@ open class KeyValueStorage<T : Any>(
      *
      * @see deleteStale
      */
-    fun deleteExpired(expiresAfter: Instant = Clock.System.now()) = transaction {
+    fun deleteExpired(expiresAfter: Instant = Clock.System.now()) = runTransaction {
         metadataQueries.purgeExpires(entityName, expiresAfter.toEpochMilliseconds())
         updateWriteAt()
     }
@@ -476,7 +481,7 @@ open class KeyValueStorage<T : Any>(
     fun deleteStale(
         writeInstant: Instant? = Clock.System.now(),
         readInstant: Instant? = Clock.System.now(),
-    ) = transaction {
+    ) = runTransaction {
         when {
             writeInstant != null && readInstant != null -> {
                 metadataQueries.purgeStale(
@@ -500,7 +505,7 @@ open class KeyValueStorage<T : Any>(
                 )
             }
 
-            else -> return@transaction
+            else -> return@runTransaction
         }
         updateWriteAt()
     }
@@ -571,9 +576,11 @@ open class KeyValueStorage<T : Any>(
      * update the write_at once.
      */
     internal fun SqkonTransactionScope.updateWriteAt() {
-        val requestHash = transacter.currentParentTransactionHash()
+        val requestHash = transacter.currentOutermostTransactionHash()
         if (requestHash in updateWriteHashes) return
         updateWriteHashes.add(requestHash)
+        // On rollback afterCommit never fires, so release the dedup entry here to avoid leaking it.
+        afterRollback { updateWriteHashes.remove(requestHash) }
         afterCommit {
             updateWriteHashes.remove(requestHash)
             scope.launch(writeDispatcher) {

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt
@@ -1,0 +1,39 @@
+package com.mercury.sqkon.db
+
+/**
+ * Sqkon-owned transaction scope, the receiver of [transaction] / [transactionWithResult].
+ *
+ * Replaces direct exposure of SQLDelight's `Transacter` / `TransactionCallbacks`. `sealed` — only
+ * Sqkon provides implementations; callers must not implement it.
+ */
+sealed interface SqkonTransactionScope {
+
+    /** Run [action] after the outermost enclosing transaction commits. */
+    fun afterCommit(action: () -> Unit)
+
+    /** Run [action] after the transaction rolls back. */
+    fun afterRollback(action: () -> Unit)
+
+    /**
+     * Abort the transaction.
+     *
+     * In [transaction] this returns silently to the caller (the work is discarded). In
+     * [transactionWithResult] there is no value to return, so it throws [SqkonRollbackException].
+     * In either case the database transaction (and any enclosing one — there are no savepoints) is
+     * rolled back.
+     */
+    fun rollback(): Nothing
+
+    /**
+     * Run [body] in a nested transaction. A nested rollback rolls back the enclosing transaction
+     * too (no savepoint semantics).
+     */
+    fun transaction(body: SqkonTransactionScope.() -> Unit)
+}
+
+/**
+ * Thrown out of [transactionWithResult] when [SqkonTransactionScope.rollback] is called: a
+ * result-returning transaction has no value to hand back on rollback, so it aborts by throwing.
+ */
+class SqkonRollbackException internal constructor() :
+    RuntimeException("Sqkon transaction rolled back")

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonTransactionScope.kt
@@ -15,12 +15,11 @@ sealed interface SqkonTransactionScope {
     fun afterRollback(action: () -> Unit)
 
     /**
-     * Abort the transaction.
+     * Abort the transaction by throwing [SqkonRollbackException], rolling back the database
+     * transaction (and any enclosing one — there are no savepoints).
      *
-     * In [transaction] this returns silently to the caller (the work is discarded). In
-     * [transactionWithResult] there is no value to return, so it throws [SqkonRollbackException].
-     * In either case the database transaction (and any enclosing one — there are no savepoints) is
-     * rolled back.
+     * [transaction] swallows the exception, so a rollback there returns silently to the caller.
+     * [transactionWithResult] lets it propagate, since there is no value to return on rollback.
      */
     fun rollback(): Nothing
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt
@@ -1,7 +1,6 @@
 package com.mercury.sqkon.db
 
-import app.cash.sqldelight.TransactionWithReturn
-import app.cash.sqldelight.TransactionWithoutReturn
+import app.cash.sqldelight.TransactionCallbacks
 import com.mercury.sqkon.db.internal.SqkonTransacter
 
 /**
@@ -10,40 +9,30 @@ import com.mercury.sqkon.db.internal.SqkonTransacter
  * returns silently.
  */
 fun <T : Any> KeyValueStorage<T>.transaction(body: SqkonTransactionScope.() -> Unit): Unit =
-    transaction(body) // resolves to the internal member (members win over extensions)
+    runTransaction(body)
 
 /**
  * Run [body] in a database transaction and return its value. Calling [SqkonTransactionScope.rollback]
  * aborts the transaction and throws [SqkonRollbackException] (there is no value to return).
  */
 fun <T : Any, R> KeyValueStorage<T>.transactionWithResult(body: SqkonTransactionScope.() -> R): R =
-    transactionWithResult(body) // resolves to the internal member
+    runTransactionWithResult(body)
 
-/** Scope backing the `Unit` transaction path. Wraps SQLDelight's [TransactionWithoutReturn]. */
+/**
+ * Adapts a SQLDelight transaction body to [SqkonTransactionScope]. [rollback] always throws
+ * [SqkonRollbackException]; the `Unit` [transaction] entry point swallows it (silent abort) while
+ * [transactionWithResult] lets it propagate. The thrown exception escaping the body is what drives
+ * SQLDelight to roll the (possibly enclosing) transaction back.
+ */
 internal class SqlDelightTransactionScope(
-    private val tx: TransactionWithoutReturn,
+    private val callbacks: TransactionCallbacks,
     private val transacter: SqkonTransacter,
 ) : SqkonTransactionScope {
-    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
-    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
-    override fun rollback(): Nothing = tx.rollback()
-    override fun transaction(body: SqkonTransactionScope.() -> Unit) {
-        // Route nesting through SqkonTransacter so trxMap records the parent link.
-        transacter.transaction(noEnclosing = false) {
-            SqlDelightTransactionScope(this, transacter).body()
-        }
-    }
-}
-
-/** Scope backing the result path. Wraps SQLDelight's [TransactionWithReturn]; rollback throws. */
-internal class SqlDelightResultTransactionScope<R>(
-    @Suppress("unused") private val tx: TransactionWithReturn<R>,
-    private val transacter: SqkonTransacter,
-) : SqkonTransactionScope {
-    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
-    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
+    override fun afterCommit(action: () -> Unit) = callbacks.afterCommit(action)
+    override fun afterRollback(action: () -> Unit) = callbacks.afterRollback(action)
     override fun rollback(): Nothing = throw SqkonRollbackException()
     override fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        // Route nesting through SqkonTransacter so trxMap records the parent link.
         transacter.transaction(noEnclosing = false) {
             SqlDelightTransactionScope(this, transacter).body()
         }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Transactions.kt
@@ -1,0 +1,51 @@
+package com.mercury.sqkon.db
+
+import app.cash.sqldelight.TransactionWithReturn
+import app.cash.sqldelight.TransactionWithoutReturn
+import com.mercury.sqkon.db.internal.SqkonTransacter
+
+/**
+ * Run [body] in a database transaction. Replaces the SQLDelight `Transacter.transaction { }` that
+ * [KeyValueStorage] used to inherit. Calling [SqkonTransactionScope.rollback] discards the work and
+ * returns silently.
+ */
+fun <T : Any> KeyValueStorage<T>.transaction(body: SqkonTransactionScope.() -> Unit): Unit =
+    transaction(body) // resolves to the internal member (members win over extensions)
+
+/**
+ * Run [body] in a database transaction and return its value. Calling [SqkonTransactionScope.rollback]
+ * aborts the transaction and throws [SqkonRollbackException] (there is no value to return).
+ */
+fun <T : Any, R> KeyValueStorage<T>.transactionWithResult(body: SqkonTransactionScope.() -> R): R =
+    transactionWithResult(body) // resolves to the internal member
+
+/** Scope backing the `Unit` transaction path. Wraps SQLDelight's [TransactionWithoutReturn]. */
+internal class SqlDelightTransactionScope(
+    private val tx: TransactionWithoutReturn,
+    private val transacter: SqkonTransacter,
+) : SqkonTransactionScope {
+    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
+    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
+    override fun rollback(): Nothing = tx.rollback()
+    override fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        // Route nesting through SqkonTransacter so trxMap records the parent link.
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+}
+
+/** Scope backing the result path. Wraps SQLDelight's [TransactionWithReturn]; rollback throws. */
+internal class SqlDelightResultTransactionScope<R>(
+    @Suppress("unused") private val tx: TransactionWithReturn<R>,
+    private val transacter: SqkonTransacter,
+) : SqkonTransactionScope {
+    override fun afterCommit(action: () -> Unit) = tx.afterCommit(action)
+    override fun afterRollback(action: () -> Unit) = tx.afterRollback(action)
+    override fun rollback(): Nothing = throw SqkonRollbackException()
+    override fun transaction(body: SqkonTransactionScope.() -> Unit) {
+        transacter.transaction(noEnclosing = false) {
+            SqlDelightTransactionScope(this, transacter).body()
+        }
+    }
+}

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt
@@ -7,10 +7,11 @@ import app.cash.sqldelight.TransactionWithoutReturn
 import app.cash.sqldelight.db.SqlDriver
 
 /**
- * Sqkon-owned transacter. Phase 2 still rides `TransacterImpl(SqlDriver)` so
- * `KeyValueStorage : Transacter by transacter` keeps working publicly.
- * Phase 5 flips the constructor to take `SqkonDriver` and drops the
- * `TransacterImpl` extension behind a `feat!:` 2.0 bump.
+ * Sqkon-owned transacter. Rides `TransacterImpl(SqlDriver)` and tracks each transaction's
+ * child -> parent link ([trxMap]) so [currentOutermostTransactionHash] can identify the outermost
+ * enclosing transaction — used to dedup per-transaction side effects across nested writes.
+ *
+ * Still SQLDelight-backed; Phase 6 swaps the constructor to `SqkonDriver` and drops `TransacterImpl`.
  */
 open class SqkonTransacter(driver: SqlDriver) : TransacterImpl(driver) {
 
@@ -22,9 +23,9 @@ open class SqkonTransacter(driver: SqlDriver) : TransacterImpl(driver) {
      * [driver]. Used to dedup per-transaction side effects (e.g. the metadata write_at touch) so a
      * batch of nested writes only schedules one afterCommit. Must be called inside a transaction.
      */
-    internal fun currentParentTransactionHash(): Int {
+    internal fun currentOutermostTransactionHash(): Int {
         val current = driver.currentTransaction()
-            ?: error("currentParentTransactionHash() called outside a transaction")
+            ?: error("currentOutermostTransactionHash() called outside a transaction")
         return current.outermostHash()
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonTransacter.kt
@@ -17,10 +17,19 @@ open class SqkonTransacter(driver: SqlDriver) : TransacterImpl(driver) {
     // Child -> Parent
     protected val trxMap = mutableMapOf<Transacter.Transaction, Transacter.Transaction?>()
 
-    fun Transacter.Transaction.parentTransactionHash(): Int {
-        // Walk up the chain. Top level: hash of self.
-        return trxMap[this]?.parentTransactionHash() ?: this.hashCode()
+    /**
+     * Stable identity hash of the *outermost* transaction enclosing the one currently running on
+     * [driver]. Used to dedup per-transaction side effects (e.g. the metadata write_at touch) so a
+     * batch of nested writes only schedules one afterCommit. Must be called inside a transaction.
+     */
+    internal fun currentParentTransactionHash(): Int {
+        val current = driver.currentTransaction()
+            ?: error("currentParentTransactionHash() called outside a transaction")
+        return current.outermostHash()
     }
+
+    private fun Transacter.Transaction.outermostHash(): Int =
+        trxMap[this]?.outermostHash() ?: this.hashCode()
 
     override fun transaction(
         noEnclosing: Boolean,

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
@@ -14,6 +14,7 @@ import org.junit.After
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.milliseconds
 
 class KeyValueStorageTransactionTest {
@@ -99,6 +100,28 @@ class KeyValueStorageTransactionTest {
         }
         // Both callbacks registered; both must fire after the OUTERMOST commit.
         until { fired.get() == 2 }
+    }
+
+    @Test
+    fun transactionWithResult_commitReturnsValue() = runTest {
+        val inserted = storage.transactionWithResult {
+            storage.insert("twr", TestObject())
+            42
+        }
+        assertEquals(42, inserted)
+        assertEquals(1, storage.count().first())
+    }
+
+    @Test
+    fun transactionWithResult_rollbackThrowsAndAborts() = runTest {
+        assertFailsWith<SqkonRollbackException> {
+            storage.transactionWithResult<TestObject, Int> {
+                storage.insert("twr", TestObject())
+                rollback()
+            }
+        }
+        // DB rolled back: the insert is gone.
+        assertEquals(0, storage.count().first())
     }
 
     private companion object {

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTransactionTest.kt
@@ -124,6 +124,23 @@ class KeyValueStorageTransactionTest {
         assertEquals(0, storage.count().first())
     }
 
+    @Test
+    fun transactionWithResult_nestedRollbackThrowsSqkonRollback() = runTest {
+        // A rollback in a nested block surfaces as SqkonRollbackException (not SQLDelight's internal
+        // type) and aborts the whole enclosing result transaction.
+        assertFailsWith<SqkonRollbackException> {
+            storage.transactionWithResult<TestObject, Int> {
+                storage.insert("outer", TestObject())
+                transaction {
+                    storage.insert("inner", TestObject())
+                    rollback()
+                }
+                99
+            }
+        }
+        assertEquals(0, storage.count().first())
+    }
+
     private companion object {
         /** Wall-clock window for the metadata-write afterCommit microtask to settle. */
         val AFTER_COMMIT_SETTLE = 50.milliseconds

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt
@@ -20,9 +20,9 @@ class SqkonTransacterParentTest {
         var outerHash = 0
         var innerParentHash = 0
         transacter.transaction {
-            outerHash = transacter.currentParentTransactionHash()
+            outerHash = transacter.currentOutermostTransactionHash()
             transacter.transaction {
-                innerParentHash = transacter.currentParentTransactionHash()
+                innerParentHash = transacter.currentOutermostTransactionHash()
             }
         }
         assertEquals(outerHash, innerParentHash)
@@ -34,7 +34,7 @@ class SqkonTransacterParentTest {
         var parentHash = 0
         transacter.transaction {
             selfHash = sqlDriver.currentTransaction()!!.hashCode()
-            parentHash = transacter.currentParentTransactionHash()
+            parentHash = transacter.currentOutermostTransactionHash()
         }
         assertEquals(selfHash, parentHash)
     }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/internal/SqkonTransacterParentTest.kt
@@ -20,11 +20,9 @@ class SqkonTransacterParentTest {
         var outerHash = 0
         var innerParentHash = 0
         transacter.transaction {
-            outerHash = sqlDriver.currentTransaction()!!.hashCode()
+            outerHash = transacter.currentParentTransactionHash()
             transacter.transaction {
-                with(transacter) {
-                    innerParentHash = sqlDriver.currentTransaction()!!.parentTransactionHash()
-                }
+                innerParentHash = transacter.currentParentTransactionHash()
             }
         }
         assertEquals(outerHash, innerParentHash)
@@ -35,11 +33,8 @@ class SqkonTransacterParentTest {
         var selfHash = 0
         var parentHash = 0
         transacter.transaction {
-            with(transacter) {
-                val current = sqlDriver.currentTransaction()!!
-                selfHash = current.hashCode()
-                parentHash = current.parentTransactionHash()
-            }
+            selfHash = sqlDriver.currentTransaction()!!.hashCode()
+            parentHash = transacter.currentParentTransactionHash()
         }
         assertEquals(selfHash, parentHash)
     }


### PR DESCRIPTION
## Summary
Phase 5 of the SQLDelight migration ([MOB-3292](https://linear.app/mercury/issue/MOB-3292)). Removes `app.cash.sqldelight.Transacter` and `TransactionCallbacks` from Sqkon's public API:

- `KeyValueStorage` no longer `: Transacter by transacter`.
- New public `sealed interface SqkonTransactionScope` + `transaction { }` / `transactionWithResult { }` extension functions on `KeyValueStorage<T>`; `rollback()`, `afterCommit`, `afterRollback`, nested transactions.
- `transactionWithResult { rollback() }` throws `SqkonRollbackException` (no value to return); `transaction { rollback() }` returns silently (unchanged SQLDelight behavior).
- Internal machinery (`SqkonTransacter`) stays SQLDelight-backed — the driver swap is Phase 6 (MOB-3293).

**BREAKING (2.0):** consumers holding `val x: Transacter = store` or importing `TransactionCallbacks` must move to the `transaction { }` extension. release-please cuts 2.0 from the `feat!:` prefix.

## Test Plan
- [x] `./gradlew :library:jvmTest` green — gate `KeyValueStorageTransactionTest` (5 cases) unchanged + 2 new `transactionWithResult` cases; `updateWriteAtOnlyRunsOncePerTransaction` proves the nested dedup still works.
- [x] `./gradlew :library:compileDebugKotlinAndroid` green.
- [ ] CI `run-android-tests` + `Compile iOS targets` green.

Plan: `docs/superpowers/plans/2026-05-22-mob-3292-hide-transacter-behind-sqkontransactionscope.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)