### PR TITLE
chore!: strip unused sqldelight plugin + runtime deps (3.0.0 cleanup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Sqkon is a Kotlin Multiplatform key-value storage library built on SQLDelight and kotlinx.serialization. It stores serialized Kotlin objects in SQLite and supports querying on JSON fields using JSONB. Targets: Android and JVM.
+Sqkon is a Kotlin Multiplatform key-value storage library built on androidx.sqlite (bundled) and kotlinx.serialization. It stores serialized Kotlin objects in SQLite and supports querying on JSON fields using JSONB. Targets: Android and JVM (iOS scaffold present).
 
 ## Build & Test
 
@@ -9,7 +9,7 @@ Run `./gradlew jvmTest` for the primary development loop. Always run this before
 ```bash
 ./gradlew jvmTest                          # Run all JVM tests
 ./gradlew jvmTest --tests "*.KeyValueStorageTest"  # Single test class
-./gradlew jvmTest --tests "*.SchemaParityTest" --tests "*.SchemaMigrationTest"  # Schema gate (replaces verifySqlDelightMigration)
+./gradlew jvmTest --tests "*.SchemaParityTest" --tests "*.SchemaMigrationTest"  # Schema gate
 ./gradlew allDevicesDebugAndroidTest       # Android instrumented tests (CI only)
 ./gradlew publishToMavenLocal              # Local Maven for integration testing
 ```
@@ -21,17 +21,15 @@ Single `:library` module with KMP source sets (`commonMain`, `androidMain`, `jvm
 **Core classes** (package `com.mercury.sqkon.db`):
 - `Sqkon` — entry point; use `sqkon.keyValueStore<T>(name)` to create stores
 - `KeyValueStorage<T>` — CRUD, querying, paging, expiry; all queries return `Flow<T>`
-- `EntityQueries` / `MetadataQueries` — SQLDelight-generated + hand-written extensions
+- `EntityQueries` / `MetadataQueries` — hand-rolled query layer over the internal `SqkonDriver`
 - `JsonPath` — type-safe WHERE DSL (`MyType::field eq "value"`)
 
-**SQLDelight schema**: `library/src/commonMain/sqldelight/com/mercury/sqkon/db/`
-**Migrations**: `library/src/commonMain/sqldelight/migrations/`
+**Schema + migrations**: `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/`
 
 Platform-specific code uses expect/actual (`*.android.kt`, `*.jvm.kt`).
 
 ## Rules
 
-- Do not set `generateAsync = true` in SQLDelight — the driver breaks on multithreaded platforms. Coroutines handle concurrency.
 - Keep the `-Xexpect-actual-classes` compiler flag — required for KMP expect/actual.
 - Do not add Android unit tests (`enableUnitTest = false`). Use JVM tests for fast iteration, Android instrumented tests for device-specific behavior.
 - Java 21 toolchain is required. Do not downgrade.
@@ -65,7 +63,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/). Release-please
 | `fix:` | patch | `fix: null handling in JsonPath` |
 | `feat!:` / `fix!:` | **major** | `feat!: remove deprecated expiry API` |
 | `perf:` | patch | `perf: optimize JSONB query plan` |
-| `deps:` | patch | `deps: upgrade SQLDelight to 2.1` |
+| `deps:` | patch | `deps: upgrade kotlinx-coroutines to 1.12.0` |
 | `docs:` | none | `docs: update README examples` |
 | `chore:` | none | `chore: update CI action versions` |
 

--- a/README.MD
+++ b/README.MD
@@ -228,12 +228,13 @@ dependencies {
 
 ## Project Requirements
 
-The project is built upon [SQLDelight](https://github.com/sqldelight/sqldelight)
-and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization), these are transitive
-dependencies, but you will not be able to use the library with applying the
-kotlinx-serialization plugin. If you are not using kotlinx serialization, I suggest you read about
-it
-here: https://github.com/Kotlin/kotlinx.serialization.
+The project is built on [`androidx.sqlite`](https://developer.android.com/jetpack/androidx/releases/sqlite)
+(bundled driver) and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization);
+these are transitive dependencies, but you will need to apply the kotlinx-serialization plugin in
+your build. If you are not using kotlinx serialization, I suggest you read about it
+here: https://github.com/Kotlin/kotlinx.serialization. Earlier versions (≤ 2.x) ran on
+[SQLDelight](https://github.com/sqldelight/sqldelight) — see `docs/superpowers/plans/` for the
+migration history.
 
 ## Expiry/Cache Busting
 

--- a/README.MD
+++ b/README.MD
@@ -231,7 +231,7 @@ dependencies {
 The project is built on [`androidx.sqlite`](https://developer.android.com/jetpack/androidx/releases/sqlite)
 (bundled driver) and [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization);
 these are transitive dependencies, but you will need to apply the kotlinx-serialization plugin in
-your build. If you are not using kotlinx serialization, I suggest you read about it
+your build. If you are not using `kotlinx.serialization`, I suggest you read about it
 here: https://github.com/Kotlin/kotlinx.serialization. Earlier versions (≤ 2.x) ran on
 [SQLDelight](https://github.com/sqldelight/sqldelight) — see `docs/superpowers/plans/` for the
 migration history.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.android.library).apply(false)
     alias(libs.plugins.multiplatform).apply(false)
     alias(libs.plugins.kotlinx.serialization).apply(false)
-    alias(libs.plugins.sqlDelight).apply(false)
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.maven.publish).apply(false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = { require = "1.11.0" }
 kotlinx-datetime = "0.8.0"
 paging = "3.5.0-rc01"
-sqlDelight = "2.3.2"
 turbine = "1.2.1"
 
 [libraries]
@@ -27,10 +26,6 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 paging-testing = { module = "androidx.paging:paging-testing", version.ref = "paging" }
-sqlDelight-androidx-driver = { module = "com.eygraber:sqldelight-androidx-driver", version = "0.0.17" }
-sqlDelight-driver-sqlite = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
-sqlDelight-driver-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
-sqlDelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 
@@ -42,4 +37,3 @@ maven-publish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,10 +8,6 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.kotlinx.serialization)
-    // Codegen is no longer used (schema is hand-rolled in internal/schema); the plugin is kept
-    // only so Phase 7 can remove it in one isolated step. It logs a harmless "no databases set
-    // up" warning until then. Runtime SQLDelight artifacts are separate deps and still required.
-    alias(libs.plugins.sqlDelight)
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
 }
@@ -56,8 +52,6 @@ kotlin {
             implementation(libs.androidx.sqlite.core)
             implementation(libs.androidx.sqlite.bundled)
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.sqlDelight.androidx.driver)
-            implementation(libs.sqlDelight.coroutines)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.datetime)
             implementation(libs.paging.common)
@@ -73,12 +67,10 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.kotlinx.coroutines.android)
-            implementation(libs.sqlDelight.driver.android)
         }
 
         jvmMain.dependencies {
             implementation(libs.kotlinx.coroutines.swing)
-            api(libs.sqlDelight.androidx.driver) // Expose the driver for transitive dependencies
         }
 
     }


### PR DESCRIPTION
## Summary
Removes the unused SQLDelight gradle plugin and runtime dependencies left over
after #60 (Phase 6 swapped to a native androidx.sqlite driver).

- `library/build.gradle.kts`: drop `alias(libs.plugins.sqlDelight)`; drop the 4 sqldelight `implementation`/`api` lines (commonMain ×2, androidMain ×1, jvmMain api ×1).
- `build.gradle.kts` (root): drop `alias(libs.plugins.sqlDelight).apply(false)`.
- `gradle/libs.versions.toml`: drop the `sqlDelight` version, 4 library aliases, 1 plugin alias.
- `CLAUDE.md`: replace 5 stale references with androidx.sqlite + hand-rolled schema/migrations facts.
- `README.MD`: replace the "built upon SQLDelight" line.

**Source code untouched** — `commonMain` / `androidMain` / `jvmMain` / `iosMain` were already sqldelight-free after #60. The remaining KDoc + Apache-2.0 attribution mentions in `SqkonDriver.kt`, `SqkonQuery.kt`, `SqkonTransacter.kt` are kept (the last is a legal requirement for derivative work).

## Breaking change
Removes the transitive `api()` exposure of `com.eygraber:sqldelight-androidx-driver` that 2.x consumers might have pulled in through sqkon. After #60 (which dropped `AndroidxSqliteDatabaseType` as a public factory param in favor of `SqkonDatabaseType`), no consumer should be relying on this transitive — but we mark `!:` for changelog honesty so the removal lands in the 3.0.0 release-please PR (#56) rather than after.

## Order of operations
Must merge **before** release PR #56. After #56 merges as 3.0.0, a fresh `chore!:` would trigger 4.0.0 from release-please.

## Test plan
- [x] `./gradlew :library:jvmTest --rerun-tasks` green (204 tests, 0 failed, 1 skipped).
- [x] `./gradlew :library:compileKotlinIosSimulatorArm64` green.
- [x] Dep tree audit: zero sqldelight/eygraber in `commonMainImplementation`, `jvmRuntimeClasspath`, `releaseRuntimeClasspath`.
- [ ] CI `jvm-tests` + `run-android-tests` + `Compile iOS targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)