### PR TITLE
chore: align docs with androidx.sqlite migration + sqldelight-import guard (MOB-3294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Build and publish
-        run: ./gradlew jvmTest
+        run: ./gradlew checkNoSqlDelightImports jvmTest
 
       - name: JUnit Report
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,7 +1,7 @@
 # Sqkon Development Guidelines
 
 ## Project Overview
-Sqkon is a Kotlin Multiplatform library for key-value storage built on top of SQLDelight and AndroidX SQLite. It provides a type-safe, coroutine-based API with Flow support for reactive data access.
+Sqkon is a Kotlin Multiplatform library for key-value storage built on AndroidX SQLite (bundled driver) with a hand-rolled schema and query layer. It provides a type-safe, coroutine-based API with Flow support for reactive data access.
 
 ## Build Configuration
 
@@ -16,22 +16,15 @@ The project uses `-Xexpect-actual-classes` compiler flag for multiplatform expec
 - Root `build.gradle.kts` for all subprojects
 - `library/build.gradle.kts` for the library module
 
-### SQLDelight Configuration
-Located in `library/build.gradle.kts`:
-```kotlin
-sqldelight {
-    databases {
-        create("SqkonDatabase") {
-            generateAsync = false  // Disabled due to driver issues on multithreaded platforms
-            packageName.set("com.mercury.sqkon.db")
-            schemaOutputDirectory.set(file("src/commonMain/sqldelight/databases"))
-            dialect("app.cash.sqldelight:sqlite-3-38-dialect:$VERSION")
-        }
-    }
-}
-```
+### Database & schema
+There is no SQL codegen plugin. The schema (CREATE statements, indexes, version, and
+migrations) is hand-rolled in
+`library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonSchema.kt`,
+applied on first connection by the internal `AndroidxSqkonDriver` over `androidx.sqlite`
+(bundled SQLite build).
 
-**Key Point**: `generateAsync = false` is intentionally disabled as async operations are problematic with coroutines on multithreaded platforms (driver limitation).
+**Key Point**: the SQLite driver is synchronous; Sqkon serializes work through its own
+coroutine dispatchers (one writer, a small reader pool) rather than an async driver.
 
 ### Source Sets
 - `commonMain`: Common code for all platforms
@@ -118,7 +111,7 @@ class MyTest {
 #### Key Components:
 1. **MainScope**: Required for background database operations
 2. **driverFactory()**: Expect/actual function providing platform-specific test drivers
-   - JVM: In-memory database (`AndroidxSqliteDatabaseType.Memory`)
+   - JVM: In-memory database (`SqkonDatabaseType.Memory`)
    - Android: Context-based test database
 3. **tearDown**: Always cancel MainScope to prevent resource leaks
 4. **runTest**: Wraps suspend test functions for coroutine testing
@@ -203,23 +196,22 @@ Key expect/actual declarations:
 - `driverFactory()`: Test database setup
 - `Sqkon.create()`: Platform-specific initialization
 
-### SQLDelight Schema Management
-- Schema files: `library/src/commonMain/sqldelight/com/mercury/sqkon/db/`
-  - `entity.sq`: Entity storage queries
-  - `metadata.sq`: Metadata tracking queries
-- Migrations: `library/src/commonMain/sqldelight/migrations/`
-- Schema output: `library/src/commonMain/sqldelight/databases/`
+### Schema Management
+- Hand-rolled schema (CREATE statements, indexes, version, migrations):
+  `library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonSchema.kt`
+- Two tables: `entity` (every stored value as JSONB) and `metadata` (per-store read/write times)
+- Applied on first connection by `AndroidxSqkonDriver`; no `.sq`/`.sqm` files, no codegen
 
 ### Core Architecture
 - **KeyValueStorage**: Main API for type-safe storage operations
-- **EntityQueries**: Generated SQLDelight queries for entities
-- **MetadataQueries**: Generated SQLDelight queries for metadata
+- **SqkonDriver**: internal synchronous SQLite driver contract; production impl is `AndroidxSqkonDriver` over `androidx.sqlite`
+- **EntityQueries**: hand-written entity queries over the driver
+- **MetadataQueries**: hand-written metadata queries over the driver
 - **KotlinSqkonSerializer**: Kotlinx.serialization-based JSON serialization
 - **Flow-based**: All queries return Flows for reactive updates
 
 ### Key Libraries
-- **SQLDelight 2.1.0**: Type-safe SQL generation
-- **AndroidX SQLite**: Cross-platform SQLite driver
+- **AndroidX SQLite (bundled)**: cross-platform SQLite driver Sqkon runs on
 - **Kotlinx Serialization 1.9.0**: JSON serialization
 - **Kotlinx Coroutines 1.10.2**: Async operations
 - **Kotlinx Datetime 0.6.2**: Timestamp handling
@@ -280,7 +272,6 @@ storage.transaction {
 ```
 
 ### Debugging Tips
-- Enable SQLDelight query logging by setting appropriate log levels
 - Use `slowWrite = true` on EntityQueries for testing transaction boundaries
 - Flow emissions can be tested with Turbine's `expectNoEvents()` to ensure operations are properly batched
 - Check that MainScope is properly cancelled in tests to avoid resource leaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Sqkon uses [Conventional Commits](https://www.conventionalcommits.org/). Release
 | `fix:`             | patch        | `fix: null handling in JsonPath`                  |
 | `feat!:` / `fix!:` | **major**    | `feat!: remove deprecated expiry API`             |
 | `perf:`            | patch        | `perf: optimize JSONB query plan`                 |
-| `deps:`            | patch        | `deps: upgrade SQLDelight to 2.1`                 |
+| `deps:`            | patch        | `deps: upgrade kotlinx-coroutines to 1.12.0`      |
 | `docs:`            | none         | `docs: update README examples`                    |
 | `chore:`           | none         | `chore: update CI action versions`                |
 
@@ -84,7 +84,7 @@ Releases are fully automated via [release-please](https://github.com/googleapis/
 
 A few constraints exist for technical reasons. Please don't change these without discussion.
 
-- **Do not set `generateAsync = true` in SQLDelight.** The async driver breaks on multithreaded platforms; coroutines handle concurrency at the API layer.
+- **Keep the SQLite driver synchronous.** Sqkon serializes work through its own coroutine dispatchers (one writer, a small reader pool); don't reach for an async driver — it doesn't play well with multithreaded hosts.
 - **Keep the `-Xexpect-actual-classes` compiler flag.** It's required for the KMP `expect`/`actual` declarations Sqkon relies on.
 - **Do not add Android unit tests** (`enableUnitTest = false`). Use JVM tests for fast iteration; Android instrumented tests cover device-specific behavior.
 - **Java 21 toolchain is required.** Do not downgrade.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -8,9 +8,10 @@ nav_order: 2
 # Architecture
 
 Sqkon takes typed Kotlin objects, runs them through `kotlinx.serialization` to JSON,
-and stores them as JSONB blobs in a single SQLite table. Reads and writes go through
-SQLDelight, which gives us type-safe SQL, automatic Flow invalidation, and a single
-driver abstraction across Android and JVM. Queries built with the `JsonPath` DSL
+and stores them as JSONB blobs in a single SQLite table. Reads and writes go through a
+hand-written query layer on top of `androidx.sqlite` (the bundled SQLite build), behind
+an internal `SqkonDriver` abstraction that gives us type-safe Kotlin call sites, Flow
+invalidation, and a single driver shape across Android and JVM. Queries built with the `JsonPath` DSL
 compile down to `json_tree`-based predicates against the stored JSON — pushing all
 filtering into SQLite's query planner instead of materializing rows in Kotlin.
 
@@ -21,13 +22,13 @@ flowchart LR
     App["App code"] --> KVS["KeyValueStorage&lt;T&gt;"]
     KVS --> Ser["KotlinSqkonSerializer"]
     KVS --> JP["JsonPath DSL"]
-    Ser --> SD["SQLDelight EntityQueries"]
+    Ser --> SD["EntityQueries"]
     JP --> SD
-    SD --> Drv["SQLite Driver"]
+    SD --> Drv["SqkonDriver (androidx.sqlite)"]
     Drv --> DB[("SQLite + JSONB")]
 ```
 
-- **`Sqkon`** — the entry point. Holds the SQLDelight queries, a serializer, a
+- **`Sqkon`** — the entry point. Holds the query objects, a serializer, a
   `CoroutineScope`, and read/write dispatchers. Use `sqkon.keyValueStorage<T>(name)`
   to spawn typed stores.
 - **`KeyValueStorage<T>`** — the per-type façade. Exposes `insert`, `update`,
@@ -40,21 +41,22 @@ flowchart LR
   parameterized `WHERE` fragments that join the row against `json_tree(entity.value)`
   and match by `fullkey LIKE '$.field' AND value <op> ?`. The final row payload is
   pulled out separately with `json_extract` in the `SELECT`.
-- **`EntityQueries` / `MetadataQueries`** — generated and hand-written SQLDelight
-  queries against the two tables described below.
-- **SQLite driver** — `androidx.sqlite` on both platforms. JVM uses an in-process
-  bundle; Android uses the system SQLite via the AndroidX driver.
+- **`EntityQueries` / `MetadataQueries`** — hand-written query classes over the
+  internal `SqkonDriver`, targeting the two tables described below.
+- **`SqkonDriver`** — Sqkon's own synchronous SQLite driver contract. The production
+  implementation, `AndroidxSqkonDriver`, runs on `androidx.sqlite` (bundled build) on
+  both platforms via a connection pool and per-connection prepared-statement cache.
 
 ## Lifecycle of an insert
 
 1. Caller invokes `storage.insert(key, value, expiresAt = ...)`.
 2. The serializer encodes `T` to a JSON byte array using the configured `Json`
    instance.
-3. SQLDelight runs an `INSERT` (or no-op if `ignoreIfExists = true` and the row
-   exists) inside a transaction.
+3. `EntityQueries` runs an `INSERT` through the driver (or no-op if
+   `ignoreIfExists = true` and the row exists) inside a transaction.
 4. SQLite stores the row with `entity_name`, `entity_key`, `value` (JSONB),
    `added_at`, `updated_at`, optional `expires_at`, and `write_at`.
-5. SQLDelight emits a notification for the affected query keys.
+5. On commit, the driver notifies the affected query keys via its listener registry.
 6. Any active `select(...)` Flows re-execute their underlying query.
 7. Consumers see a fresh emission with the new row included.
 
@@ -66,7 +68,7 @@ flowchart LR
    `json_tree(entity.value)` and filters by
    `fullkey LIKE '$.field' AND value = ?` (or `LIKE`, `IN`, `>`, `<`, `IS NOT`, etc.),
    all with parameter placeholders.
-3. SQLDelight runs the parameterized query against SQLite. Filtering happens inside
+3. The driver runs the parameterized query against SQLite. Filtering happens inside
    the database — Kotlin never sees rows that don't match.
 4. Returned blobs are deserialized back to `T` on the read dispatcher.
 5. The Flow keeps observing; subsequent writes that touch the same query trigger
@@ -87,10 +89,9 @@ flowchart LR
 
 ## Schema
 
-Sqkon uses two tables. The full SQLDelight definitions live at:
+Sqkon uses two tables. The hand-rolled schema (CREATE statements + migrations) lives at:
 
-- [`library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq`](https://github.com/MercuryTechnologies/sqkon/blob/main/library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq)
-- [`library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq`](https://github.com/MercuryTechnologies/sqkon/blob/main/library/src/commonMain/sqldelight/com/mercury/sqkon/db/metadata.sq)
+- [`library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonSchema.kt`](https://github.com/MercuryTechnologies/sqkon/blob/main/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonSchema.kt)
 
 ### `entity`
 
@@ -125,6 +126,6 @@ store. Useful for cache freshness checks and for purging stale entries.
 | `lastWriteAt` | INTEGER | Mapped to `kotlinx.datetime.Instant`.|
 
 {: .highlight }
-> Sqkon never sets `generateAsync = true` on SQLDelight — the async driver doesn't
-> play well with multithreaded JVM hosts. Coroutines and dispatchers handle
-> concurrency instead.
+> The driver is synchronous; Sqkon serializes work through its own coroutine
+> dispatchers (one writer, a small reader pool) rather than relying on an async
+> SQLite driver, which doesn't play well with multithreaded hosts.

--- a/docs/concepts/what-it-is.md
+++ b/docs/concepts/what-it-is.md
@@ -13,7 +13,8 @@ deliberately doesn't — saves you from fighting it later.
 ## Sqkon IS
 
 - A **Kotlin Multiplatform key-value store** for Android and JVM, built on
-  [SQLDelight](https://cashapp.github.io/sqldelight/) and SQLite.
+  [`androidx.sqlite`](https://developer.android.com/jetpack/androidx/releases/sqlite)
+  (bundled SQLite) with a hand-rolled schema and query layer.
 - **JSONB-queryable**: values are stored as JSONB blobs, and you can filter on any
   field of your serialized type using SQLite's native JSON operators.
 - **Reactive**: every read returns a `Flow`. Writes invalidate the relevant queries,

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -114,9 +114,8 @@ dependencies {
 ```
 
 {: .note }
-> Sqkon brings its own SQLDelight driver and the AndroidX SQLite bundled native
-> library transitively. You do **not** need to add SQLDelight or
-> `androidx.sqlite` directly unless you use them outside Sqkon.
+> Sqkon brings the AndroidX SQLite bundled native library transitively. You do
+> **not** need to add `androidx.sqlite` directly unless you use it outside Sqkon.
 
 ## Verify
 

--- a/docs/getting-started/platform-setup.md
+++ b/docs/getting-started/platform-setup.md
@@ -55,8 +55,8 @@ from there.
 ### Database file
 
 By default Sqkon writes to `sqkon.db` inside your app's standard database
-directory (the same place Room and SQLDelight Android drivers use). To pick a
-different file name, pass `dbFileName`:
+directory (the same place Room stores its databases). To pick a different file
+name, pass `dbFileName`:
 
 ```kotlin
 Sqkon(context = this, scope = appScope, dbFileName = "my-cache.db")
@@ -76,20 +76,21 @@ Sqkon(context = this, scope = appScope, dbFileName = null)
 
 ## JVM
 
-The JVM factory takes a `CoroutineScope` and an `AndroidxSqliteDatabaseType`:
+The JVM factory takes a `CoroutineScope` and a `SqkonDatabaseType`:
 
 ```kotlin
 fun Sqkon(
     scope: CoroutineScope,
     json: Json = SqkonJson { },
-    type: AndroidxSqliteDatabaseType = AndroidxSqliteDatabaseType.Memory,
+    type: SqkonDatabaseType = SqkonDatabaseType.Memory,
     config: KeyValueStorage.Config = KeyValueStorage.Config(),
+    driverConfig: SqkonDriverConfig = SqkonDriverConfig(),
 ): Sqkon
 ```
 
 ### In-memory (default)
 
-The default is `AndroidxSqliteDatabaseType.Memory`, which is ideal for unit
+The default is `SqkonDatabaseType.Memory`, which is ideal for unit
 tests:
 
 ```kotlin
@@ -101,11 +102,11 @@ val sqkon = Sqkon(scope = scope) // in-memory by default
 For a persistent JVM database, point at a file:
 
 ```kotlin
-import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
+import com.mercury.sqkon.db.SqkonDatabaseType
 
 val sqkon = Sqkon(
     scope = appScope,
-    type = AndroidxSqliteDatabaseType.File("data/sqkon.db"),
+    type = SqkonDatabaseType.FileBacked("data/sqkon.db"),
 )
 ```
 
@@ -126,12 +127,10 @@ This is configured in
 [`Sqkon.kt`](https://github.com/MercuryTechnologies/sqkon/blob/main/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt)
 and the platform `SqkonDatabaseDriver` files.
 
-{: .warning }
-> **Do not enable SQLDelight's `generateAsync = true`.** The async driver is
-> effectively broken on multithreaded platforms with coroutines. Sqkon relies on
-> the synchronous driver and serializes work through its own dispatchers — that
-> is the supported configuration. This rule is enforced in the project's
-> `library/build.gradle.kts` and called out in `CLAUDE.md`.
+{: .note }
+> Sqkon's SQLite driver is synchronous by design; it serializes work through its
+> own dispatchers (one writer, a small reader pool) rather than an async driver,
+> which doesn't play well with multithreaded hosts.
 
 The `CoroutineScope` you pass to `Sqkon(...)` is used as the parent of the
 internal reactive query coroutines. Cancel that scope (typically only in tests
@@ -139,13 +138,14 @@ or when shutting down a worker process) to release database resources.
 
 ## iOS / Native
 
-Native targets are **not currently supported**. Sqkon depends on the
-[`sqldelight-androidx-driver`](https://github.com/eygraber/sqldelight-androidx-driver)
-which is JVM/Android-only at the time of writing.
+Not usable on iOS **yet**. The iOS source set is scaffolded and compiles, but the
+platform `DriverFactory.createDriver()` is still a `TODO` stub — there is no public
+`Sqkon(...)` factory for iOS. Now that Sqkon runs on `androidx.sqlite` (which ships a
+KMP/native `BundledSQLiteDriver`), the only remaining work is wiring that actual; the
+old eygraber JVM/Android-only driver is gone.
 
 If iOS support matters to you, please open or upvote an issue on the
-[GitHub repo](https://github.com/MercuryTechnologies/sqkon/issues) — there's no
-fundamental blocker beyond a native driver wiring.
+[GitHub repo](https://github.com/MercuryTechnologies/sqkon/issues).
 
 ## Next
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -68,18 +68,18 @@ class MyApplication : Application() {
 ### JVM
 
 ```kotlin
-import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
+import com.mercury.sqkon.db.SqkonDatabaseType
 
 val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 val sqkon = Sqkon(
     scope = appScope,
-    type = AndroidxSqliteDatabaseType.File("sqkon.db"),
+    type = SqkonDatabaseType.FileBacked("sqkon.db"),
 )
 ```
 
 For tests, drop the `type` argument — the JVM default is
-`AndroidxSqliteDatabaseType.Memory`.
+`SqkonDatabaseType.Memory`.
 
 ## 3. Get a typed store
 
@@ -173,8 +173,8 @@ appScope.launch {
 ```
 
 Inserts, updates, and deletes from anywhere in your app will trigger a new
-emission automatically — Sqkon wires SQLDelight's reactive query plumbing
-through the JSONB layer.
+emission automatically — on commit, Sqkon's driver notifies the affected query
+keys and active Flows re-run their query.
 
 ## 7. Cleanup
 

--- a/docs/guides/flow.md
+++ b/docs/guides/flow.md
@@ -28,8 +28,8 @@ val meta: Flow<Metadata>               = merchants.metadata()
 
 These flows are **cold**. They start no work until something collects them and
 they cancel cleanly when the collector cancels. The first collector triggers
-the first SQL execution; subsequent emissions are driven by SQLDelight's table
-notifications.
+the first SQL execution; subsequent emissions are driven by the driver's
+query-key notifications fired on commit.
 
 ## When does it re-emit?
 
@@ -43,12 +43,12 @@ new result.
 sequenceDiagram
     participant Writer
     participant SqkonStore as KeyValueStorage(T)
-    participant SQLDelight
+    participant Driver as SqkonDriver
     participant Reader as Flow consumer
     Writer->>SqkonStore: insert(...)
-    SqkonStore->>SQLDelight: INSERT
-    SQLDelight->>SQLDelight: notify(entity)
-    SQLDelight->>SqkonStore: re-execute
+    SqkonStore->>Driver: INSERT
+    Driver->>Driver: notify(entity)
+    Driver->>SqkonStore: re-execute
     SqkonStore->>Reader: emit(updatedList)
 ```
 

--- a/docs/guides/paging.md
+++ b/docs/guides/paging.md
@@ -146,7 +146,7 @@ sequenceDiagram
     participant App
     participant Pager
     participant Source as PagingSource
-    participant DB as SQLDelight
+    participant DB as SqkonDriver
 
     App->>Pager: collect flow
     Pager->>Source: load(initial)

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -25,7 +25,7 @@ data class Merchant(val id: String, val name: String, val category: String)
 ## Built-in indexes
 
 The `entity` table ships with three indexes today (see
-`library/src/commonMain/sqldelight/com/mercury/sqkon/db/entity.sq`):
+`library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonSchema.kt`):
 
 | Index | Column | What it speeds up |
 |-------|--------|-------------------|

--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -436,7 +436,7 @@ a `WHERE` predicate, and the bound parameters. AND/OR combine two child
 queries into one. The store also adds the `entity_name = ?` filter for the
 store you opened, so two stores in the same database never collide.
 
-For the full read/write lifecycle (serializer → SQLDelight → driver →
+For the full read/write lifecycle (serializer → query layer → driver →
 SQLite), see
 [Concepts: Architecture]({{ '/concepts/architecture/' | relative_url }}).
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -142,9 +142,9 @@ on top of Sqkon:
   tests for device-specific behavior. Android unit tests on the
   Robolectric / "JVM-running-Android" path don't add coverage Sqkon
   cares about.
-- **Do not set `generateAsync = true` in SQLDelight.** The Sqkon driver
-  doesn't support it, and concurrency is already handled by the
-  read/write coroutine dispatchers Sqkon uses internally.
+- **Keep the SQLite driver synchronous.** Concurrency is handled by the
+  read/write coroutine dispatchers Sqkon uses internally; don't reach for an
+  async driver.
 
 ## Where to put test data classes
 

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -120,9 +120,9 @@ transaction for these:
 - `delete` (by `Where`), `deleteByKey`, `deleteByKeys`, `deleteAll`
 - `deleteExpired`, `deleteStale`
 
-Wrapping them in your own `transaction { … }` is harmless — SQLDelight nests —
-and is sometimes useful for grouping unrelated writes into one observer
-emission.
+Wrapping them in your own `transaction { … }` is harmless — Sqkon nests
+transactions — and is sometimes useful for grouping unrelated writes into one
+observer emission.
 
 ## Flow emission timing
 
@@ -136,7 +136,7 @@ in [Reactive flows: when does it re-emit?]({{ '/guides/flow/#when-does-it-re-emi
 {: .important }
 Since [PR #22](https://github.com/MercuryTechnologies/sqkon/pull/22)
 (commit `444823c`), Sqkon's `transaction { … }` blocks run **synchronously**
-on the calling thread, the same as SQLDelight upstream. If you're upgrading
+on the calling thread. If you're upgrading
 from a pre-`444823c` version that ran transactions on a write dispatcher,
 move any `runBlocking { … }` or `withContext(Dispatchers.IO) { … }` you added
 *around* `transaction` calls — the block already executes on whatever thread

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,8 +86,8 @@ suspend fun loadFood(): List<Merchant> =
     <span class="feature-card__desc">First-class expiry on every entry. Perfect for caches.</span>
   </a>
   <a class="feature-card" href="{{ '/concepts/architecture/' | relative_url }}">
-    <span class="feature-card__title">Built on SQLDelight</span>
-    <span class="feature-card__desc">Battle-tested SQLite, with type-safe codegen underneath.</span>
+    <span class="feature-card__title">Built on androidx.sqlite</span>
+    <span class="feature-card__desc">Battle-tested SQLite via the bundled native driver, with a type-safe Kotlin API on top.</span>
   </a>
 </div>
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -118,3 +118,35 @@ androidComponents {
         (it as HasUnitTestBuilder).enableUnitTest = false
     }
 }
+
+// MOB-3294: keep SQLDelight/eygraber imports out of the codebase after the androidx.sqlite
+// migration. Checks imports only, so the Apache-2.0 attribution KDoc that names the upstream
+// projects is left untouched. Wired into `check` and invoked directly in CI (see ci.yml).
+val checkNoSqlDelightImports by tasks.registering {
+    group = "verification"
+    description = "Fails if any app.cash.sqldelight or com.eygraber.sqldelight import returns under library/src."
+    val srcRoot = layout.projectDirectory.dir("src").asFile
+    doLast {
+        val offenders = srcRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                file.readLines().mapIndexedNotNull { i, line ->
+                    val trimmed = line.trimStart()
+                    val isImport = trimmed.startsWith("import ") &&
+                        ("app.cash.sqldelight" in trimmed || "com.eygraber.sqldelight" in trimmed)
+                    if (isImport) "${file.relativeTo(srcRoot)}:${i + 1}: ${line.trim()}" else null
+                }
+            }
+            .toList()
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("SQLDelight/eygraber imports must not return after the androidx.sqlite migration (MOB-3294):")
+                    offenders.forEach { appendLine("  $it") }
+                },
+            )
+        }
+    }
+}
+
+tasks.named("check") { dependsOn(checkNoSqlDelightImports) }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonDriver.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/SqkonDriver.kt
@@ -1,9 +1,9 @@
 package com.mercury.sqkon.db.internal
 
 /**
- * Sqkon-owned database driver contract. Phase 2 mirrors the subset of
- * `app.cash.sqldelight.db.SqlDriver` that Sqkon actually uses. The
- * SQLDelight runtime sits behind `SqlDelightSqkonDriver` until Phase 6.
+ * Sqkon-owned database driver contract: a small synchronous SQLite driver interface
+ * (originally modeled on the subset of `app.cash.sqldelight.db.SqlDriver` Sqkon used).
+ * The production implementation is `AndroidxSqkonDriver` over `androidx.sqlite`.
  */
 internal interface SqkonDriver {
 

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaParityTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaParityTest.kt
@@ -9,10 +9,11 @@ import kotlin.test.assertEquals
  * representation of the schema. Compared byte-for-byte against
  * `library/src/jvmTest/resources/sqkon-schema-v2.snapshot`.
  *
- * Replaces `verifySqlDelightMigration` as the schema canary in Phase 4.
+ * The schema canary (the hand-rolled-schema successor to the old SQLDelight
+ * migration verifier).
  *
  * To regenerate after an INTENTIONAL schema change:
- *   1. Add a new SQLDelight migration .sqm file (bumps Schema.version).
+ *   1. Bump the version and add the migration SQL in `internal/schema/SqkonSchema.kt`.
  *   2. Delete the snapshot file.
  *   3. Re-run this test — it writes the new snapshot on first run.
  *   4. Inspect the diff before committing.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,11 +42,6 @@ dependencyResolutionManagement {
                 includeGroup("com.mercury.sqkon")
             }
         }
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots") {
-            content {
-                includeGroup("com.eygraber")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
Post-#61 cleanup. The 7-phase SQLDelight → androidx.sqlite migration is complete on `main`, but documentation still described the old SQLDelight-backed architecture and two getting-started examples used the **removed** eygraber `AndroidxSqliteDatabaseType` API (would not compile against 3.0.0).

### Docs (~17 files)
Rewrote architecture / what-it-is / quickstart / platform-setup / flow / paging / querying / performance / transactions / installation / index pages + `.junie/guidelines.md` + `CONTRIBUTING.md` to describe:
- the hand-rolled schema (`internal/schema/SqkonSchema.kt`),
- the native `SqkonDriver` / `AndroidxSqkonDriver` over `androidx.sqlite` (bundled),
- `SqkonDatabaseType` (`Memory` / `FileBacked`) replacing the eygraber type,
- the synchronous-driver + coroutine-dispatcher concurrency model (the old `generateAsync` warnings are gone — the plugin no longer exists).

SQLDelight is **kept only where still accurate**: the 2.x→3.0 upgrade history (`transactions.md`) and the "vs raw SQLDelight" comparison pages.

### Build / CI — completes MOB-3294 exit criteria
- New `checkNoSqlDelightImports` Gradle verification task: fails if any `app.cash.sqldelight` / `com.eygraber.sqldelight` **import** returns under `library/src`. Checks imports only, so the legally-required Apache-2.0 attribution KDoc is untouched. Wired into `check` and into the `jvm-tests` CI step.
- Removed the now-unused `com.eygraber` snapshots maven repo from `settings.gradle.kts`.

### Code comments
Refreshed stale comments in `SqkonDriver.kt` (bridge deleted in #60) and `SchemaParityTest.kt` (`.sqm` workflow → `internal/schema`).

## Not breaking / no ordering constraint
`chore:` — no version bump. Unlike #61, this does **not** need to land before release PR #56; it can merge any time.

## Test plan
- [x] `./gradlew checkNoSqlDelightImports :library:jvmTest --rerun-tasks` green (guard runs + passes; 204 tests pass).
- [x] Guard negative-tested: planted `import app.cash.sqldelight…` → `BUILD FAILED` naming the file, exit 1.
- [x] `jvmTest` resolves all deps without the removed eygraber maven repo.
- [ ] CI `jvm-tests` (now runs the guard) + `run-android-tests` + `Compile iOS targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)