### PR TITLE
deps: migrate to kotlin.time.Instant, drop kotlinx-datetime (MOB-3549)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ kotlin = "2.3.21"
 agp = "8.13.2"
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = { require = "1.11.0" }
-kotlinx-datetime = "0.8.0"
 paging = "3.5.0-rc01"
 turbine = "1.2.1"
 
@@ -23,7 +22,6 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 paging-testing = { module = "androidx.paging:paging-testing", version.ref = "paging" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -28,7 +28,6 @@ dokka {
         listOf(
             "kotlinx-serialization" to "https://kotlinlang.org/api/kotlinx.serialization/",
             "kotlinx-coroutines"    to "https://kotlinlang.org/api/kotlinx.coroutines/",
-            "kotlinx-datetime"      to "https://kotlinlang.org/api/kotlinx-datetime/",
         ).forEach { (name, url) ->
             externalDocumentationLinks.register(name) {
                 this.url.set(URI(url))
@@ -53,7 +52,6 @@ kotlin {
             implementation(libs.androidx.sqlite.bundled)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)
-            implementation(libs.kotlinx.datetime)
             implementation(libs.paging.common)
             // Don't include other paging, just the base to generate pageable queries
         }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -7,9 +7,9 @@ import com.mercury.sqkon.db.internal.SqkonQuery
 import com.mercury.sqkon.db.internal.SqkonTransacter
 import com.mercury.sqkon.db.utils.nowMillis
 import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 
 class EntityQueries internal constructor(
     driver: SqkonDriver,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Metadata.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Metadata.kt
@@ -1,6 +1,6 @@
 package com.mercury.sqkon.db
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Row in the `metadata` table. [MetadataQueries] handles the `Long ↔ Instant`

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/MetadataQueries.kt
@@ -4,7 +4,7 @@ import com.mercury.sqkon.db.internal.SqkonCursor
 import com.mercury.sqkon.db.internal.SqkonDriver
 import com.mercury.sqkon.db.internal.SqkonQuery
 import com.mercury.sqkon.db.internal.SqkonTransacter
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class MetadataQueries internal constructor(
     driver: SqkonDriver,

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/ResultRow.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/ResultRow.kt
@@ -1,7 +1,7 @@
 package com.mercury.sqkon.db
 
 import kotlin.time.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class ResultRow<T : Any>(
     val addedAt: Instant,

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -1,7 +1,7 @@
 package com.mercury.sqkon
 
 import kotlin.time.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.random.Random

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageMetadataPerRowTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageMetadataPerRowTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds


### PR DESCRIPTION
## Summary
Resolves the `kotlinx.datetime.Instant` deprecation (kotlinx-datetime 0.8.0 moved `Instant` to the stdlib `kotlin.time.Instant`). Closes **MOB-3549**.

- **Import swap (7 files):** `import kotlinx.datetime.Instant` → `import kotlin.time.Instant` in `ResultRow`, `Metadata`, `MetadataQueries`, `EntityQueries`, `KeyValueStorage` (commonMain) + `TestDataClasses`, `KeyValueStorageMetadataPerRowTest` (commonTest). Import-only — every call site compiles unchanged (`Instant.fromEpochMilliseconds` / `.toEpochMilliseconds()` / nullable params / `Clock.System.now()` defaults); `Clock` was already `kotlin.time.Clock`.
- **Dropped the now-unused `kotlinx-datetime` dependency:** `Instant` was the only symbol used from it. Removed the commonMain dependency, the `libs.versions.toml` version + alias, and the kotlinx-datetime Dokka external-docs link.

## Compatibility — not breaking
`kotlinx.datetime.Instant` was a **transparent typealias** to `kotlin.time.Instant`, so:
- **Source-compatible:** callers passing an `Instant` resolve to the same type.
- **Binary-compatible:** typealiases erase to the underlying type in bytecode — public signatures (e.g. `insert(expiresAt: Instant?)`) are byte-for-byte identical before/after.
- **Wire-format identical:** both use the same built-in default serializer (ISO-8601 string); the metadata/entity columns are epoch-millis `Long` via `to/fromEpochMilliseconds()`, unchanged.

(`deps:` → patch bump.)

## Test plan
- [x] `./gradlew clean :library:jvmTest :library:compileKotlinIosSimulatorArm64 --rerun-tasks` → BUILD SUCCESSFUL; **204 tests, 0 failed, 1 skipped**.
- [x] **Zero** `kotlinx.datetime` deprecation warnings in the build (was the symptom).
- [x] `SchemaParityTest` + `SchemaMigrationTest` pass → on-disk schema/format unchanged.
- [x] `grep -rn kotlinx.datetime library/src` → no matches.
- [ ] CI `jvm-tests` (incl. `checkNoSqlDelightImports` guard) + `run-android-tests` + `Compile iOS targets` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)