### PR TITLE
ci: snapshot publishing workflow + pin/refresh action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   jvm-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Java JDK
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew checkNoSqlDelightImports jvmTest
 
       - name: JUnit Report
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: always()
         with:
           check_name: JVM Test Results
@@ -44,7 +44,7 @@ jobs:
   run-android-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Java JDK
@@ -65,7 +65,7 @@ jobs:
         run: ./gradlew allDevicesDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
 
       - name: JUnit Report
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: always()
         with:
           check_name: Android Test Results
@@ -76,7 +76,7 @@ jobs:
     name: Compile iOS targets
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Java JDK
@@ -88,4 +88,3 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Compile iOS targets
         run: ./gradlew :library:compileKotlinIosArm64 :library:compileKotlinIosSimulatorArm64
-

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,20 +29,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Full history so JTD's `last_edit_timestamp` and `gh_edit_link`
           # can resolve per-page commit timestamps.
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Build Dokka HTML
         run: ./gradlew :library:dokkaGeneratePublicationHtml
@@ -58,14 +58,14 @@ jobs:
           fi
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3.3"
           bundler-cache: true
           working-directory: docs
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build Jekyll
         env:
@@ -95,7 +95,7 @@ jobs:
             --ignore-files "/_site\/api\//"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/_site
 
@@ -109,4 +109,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-to-maven.yml
+++ b/.github/workflows/deploy-to-maven.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Java JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,6 +18,9 @@ concurrency:
 
 jobs:
   publish-snapshot:
+    # push only ever fires on main; this guards workflow_dispatch so a snapshot
+    # can never be published from an unreviewed non-main ref selected in the UI.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,11 +38,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Prefer the upcoming version from the open release-please PR
-          # (title pattern "release: X.Y.Z"); that is exactly the version
-          # currently in development.
-          TITLES="$(gh pr list --state open --json title --jq '.[].title')"
-          NEXT="$(printf '%s\n' "$TITLES" \
+          # Prefer the upcoming version from the open release-please PR (head
+          # branch "release-please--branches--main", title "release: X.Y.Z");
+          # that is exactly the version currently in development. Scoping to the
+          # release-please head branch + main base means an unrelated open PR
+          # that happens to be titled like a release can never be matched.
+          TITLE="$(gh pr list --state open --base main \
+            --head release-please--branches--main --json title --jq '.[].title')"
+          NEXT="$(printf '%s\n' "$TITLE" \
             | sed -n 's/^release: \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
             | head -n1)"
           if [ -z "$NEXT" ]; then

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,72 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Snapshots overwrite the same -SNAPSHOT coordinates, so never publish two at
+# once; let an in-flight publish finish rather than cancelling it.
+concurrency:
+  group: publish-snapshot
+  cancel-in-progress: false
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Java JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+      - name: Compute snapshot version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Prefer the upcoming version from the open release-please PR
+          # (title pattern "release: X.Y.Z"); that is exactly the version
+          # currently in development.
+          TITLES="$(gh pr list --state open --json title --jq '.[].title')"
+          NEXT="$(printf '%s\n' "$TITLES" \
+            | sed -n 's/^release: \([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+            | head -n1)"
+          if [ -z "$NEXT" ]; then
+            # No open release PR: bump the patch of the last released version
+            # recorded in the release-please manifest.
+            BASE="$(jq -r '.["."]' .release-please-manifest.json)"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+            NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            echo "No open release PR; falling back to manifest bump: ${BASE} -> ${NEXT}"
+          fi
+          VERSION="${NEXT}-SNAPSHOT"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+            echo "::error::Computed invalid snapshot version: '${VERSION}'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing snapshot version: $VERSION"
+
+      - name: Run tests before publishing
+        run: ./gradlew jvmTest
+
+      - name: Publish snapshot to Maven Central
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Java JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:


### PR DESCRIPTION
## Summary

Adds a **snapshot publishing** pipeline and tightens action pinning across all workflows.

### New: `publish-snapshot.yml`
On every push to `main` (and via manual `workflow_dispatch`):
1. Computes the **in-development version** — reads the open release-please PR title (`release: X.Y.Z`); if no release PR is open, falls back to bumping the patch of the last released version in `.release-please-manifest.json`.
2. Appends `-SNAPSHOT`, runs `jvmTest`, then publishes via the **existing** `publishAllPublicationsToMavenCentralRepository` task.

The vanniktech plugin auto-routes `-SNAPSHOT` versions to the Central Portal snapshot repository (`https://central.sonatype.com/repository/maven-snapshots/`), so this reuses the same task + signing/Central credentials as the release jobs — no new publish plumbing. A `concurrency` group prevents overlapping snapshot publishes.

With release PR #56 open today, the first run would publish **`3.0.0-SNAPSHOT`**.

### Action SHA refresh / pinning
| Workflow(s) | Action | Change |
|---|---|---|
| ci, deploy-to-maven, release-please | `actions/checkout` | v6.0.2 → **v6.0.3** |
| ci | `mikepenz/action-junit-report` | v6.4.0 → **v6.4.1** |
| deploy-docs | `actions/checkout` | `@v4` → **v6.0.3** (SHA, matches repo) |
| deploy-docs | `actions/setup-java` | `@v4` → **v5.2.0** (SHA, matches repo) |
| deploy-docs | `gradle/actions/setup-gradle` | `@v4` → **v6.1.0** (SHA, matches repo) |
| deploy-docs | `ruby/setup-ruby` | `@v1` → **v1.310.0** (SHA) |
| deploy-docs | `actions/configure-pages` | `@v5` → **v6.0.0** (SHA, node-24 bump) |
| deploy-docs | `actions/upload-pages-artifact` | `@v5` → **v5.0.0** (SHA) |
| deploy-docs | `actions/deploy-pages` | `@v5` → **v5.0.0** (SHA) |

`actions/setup-java` (v5.2.0), `gradle/actions` (v6.1.0), `googleapis/release-please-action` (v5.0.0) and vanniktech `maven-publish` (0.36.0) were already on the latest releases — verified, unchanged.

`deploy-docs.yml` previously used **unpinned floating tags**; all actions are now SHA-pinned with a version comment, consistent with the rest of the repo.

## Why `ci:`
No version-bumping change — won't disturb the pending 3.0.0 release PR (#56). No source/build files touched.

## Test plan
- [x] All 5 workflow files validate as YAML.
- [x] No stale SHAs / floating tags remain.
- [x] Version-compute logic verified against live repo state: open release PR → `3.0.0`; fallback → `2.1.1-SNAPSHOT`.
- [ ] CI `jvm-tests` + `run-android-tests` + `Compile iOS targets` green (no code changed; build inputs untouched).
- [ ] Maintainer sanity-check the snapshot publish by running `Publish Snapshot` via `workflow_dispatch` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)