### PR TITLE
ci: fix snapshot publishing (use vanniktech publishToMavenCentral task)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -68,7 +68,13 @@ jobs:
         run: ./gradlew jvmTest
 
       - name: Publish snapshot to Maven Central
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository --no-configuration-cache
+        # Use vanniktech's aggregate task, NOT
+        # publishAllPublicationsToMavenCentralRepository: the latter always
+        # uploads through the release Publisher-API deployment bundle, which
+        # validates filenames and rejects timestamped snapshots ("Deployment
+        # failed validation"). publishToMavenCentral routes a -SNAPSHOT version
+        # to the no-validation Central Portal snapshot repository instead.
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Problem

The new `publish-snapshot.yml` failed on its first run on `main` ([job log](https://github.com/MercuryTechnologies/sqkon/actions/runs/26836318353/job/79131055325)):

```
> Deployment cd1f3372-... failed validation:
  * Filename 'library-android-3.0.0-20260602.172246-1.aar' is not valid
  ...
```

It used `publishAllPublicationsToMavenCentralRepository` — Gradle's per-repo task, which always uploads through the Central Portal **release deployment/bundle API**. That path runs filename validation and rejects Gradle's *timestamped* snapshot artifacts (`3.0.0-20260602.172246-1`). It's the correct task for **releases** (which is why `deploy-to-maven` / `release-please` work), but wrong for snapshots.

## Fix

Use vanniktech's aggregate **`publishToMavenCentral`** task. Per the [plugin docs](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#publishing-snapshots), a `-SNAPSHOT` version is automatically routed to the **no-validation Central Portal snapshot repository** (`https://central.sonatype.com/repository/maven-snapshots/`). Release workflows are untouched.

Verified `:library:publishToMavenCentral` resolves locally (`gradlew help --task publishToMavenCentral` → BUILD SUCCESSFUL).

## ⚠️ Maintainer prerequisite (still required)

The `com.mercury.sqkon` namespace must have **"Enable SNAPSHOTs"** turned on in the [Central Portal namespaces page](https://central.sonatype.com/publishing/namespaces). Without it the upload will still fail (auth/permission, not validation). The Portal snapshot repo performs *no* artifact validation once enabled, so the timestamped-filename rejection will not recur.

## Test plan
- [x] YAML validates.
- [x] `publishToMavenCentral` task exists/resolves.
- [ ] After merge + namespace SNAPSHOTs enabled: confirm `3.0.0-SNAPSHOT` appears under the Central Portal snapshot repo on the next `main` push (or via `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)