### PR TITLE
ci: route snapshots correctly via VERSION_NAME (fixes Deployment validation failure)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -68,16 +68,22 @@ jobs:
         run: ./gradlew jvmTest
 
       - name: Publish snapshot to Maven Central
-        # Use vanniktech's aggregate task, NOT
-        # publishAllPublicationsToMavenCentralRepository: the latter always
-        # uploads through the release Publisher-API deployment bundle, which
-        # validates filenames and rejects timestamped snapshots ("Deployment
-        # failed validation"). publishToMavenCentral routes a -SNAPSHOT version
-        # to the no-validation Central Portal snapshot repository instead.
+        # The version MUST be supplied via VERSION_NAME (a Gradle property), not
+        # RELEASE_VERSION. vanniktech decides snapshot-vs-release routing from its
+        # own publish version (VERSION_NAME), NOT project.version: with only
+        # RELEASE_VERSION set, vanniktech still reads VERSION_NAME=<release> from
+        # gradle.properties, takes the validating release Publisher-API deployment
+        # path, and rejects the -SNAPSHOT artifacts ("Deployment failed
+        # validation: Filename ... is not valid"). Passing VERSION_NAME=<x>-SNAPSHOT
+        # flips routing to the no-validation Central Portal snapshot repository
+        # (https://central.sonatype.com/repository/maven-snapshots/). It also feeds
+        # the root build's project.version (= RELEASE_VERSION ?: VERSION_NAME), so
+        # the published artifacts carry the same version. publishToMavenCentral is
+        # the documented snapshot task.
         run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          ORG_GRADLE_PROJECT_VERSION_NAME: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}


### PR DESCRIPTION
## Problem

After #64/#65 the snapshot job *still* failed with `Deployment <uuid> failed validation: Filename ... is not valid`, even with the `publishToMavenCentral` task **and** SNAPSHOTs enabled on the namespace. The Central Portal "Deployments" list shows the tell: the deployment is named **`com.mercury.sqkon-library-1.2.0`** while its components are `…@3.0.0-SNAPSHOT`.

## Root cause (proven, not guessed)

vanniktech's plugin decides **snapshot-vs-release routing from its own publish version (the `VERSION_NAME` Gradle property), not `project.version`.** We were only setting `RELEASE_VERSION` (which feeds `project.version`). vanniktech never read it — it saw `VERSION_NAME=1.2.0` from `gradle.properties` (a *release* version), pointed the shared `mavenCentral` repository at the **release staging dir → Publisher-API deployment bundle** (which validates filenames), while the build re-stamped the *artifacts* to `3.0.0-SNAPSHOT`. The release validator then rejects Gradle's timestamped snapshot filenames. Hence the `…-1.2.0` deployment name carrying `3.0.0-SNAPSHOT` components.

Verified locally with a `projectsEvaluated` probe of the configured `mavenCentral` repository URL:

| Env | configured `mavenCentral` URL |
|---|---|
| `RELEASE_VERSION=3.0.0-SNAPSHOT` (old) | `file:…/build/publishing/mavenCentral` → release/Publisher-API path |
| `ORG_GRADLE_PROJECT_VERSION_NAME=3.0.0-SNAPSHOT` (this PR) | `https://central.sonatype.com/repository/maven-snapshots/` → snapshot path |

## Fix

Export the computed version as **`ORG_GRADLE_PROJECT_VERSION_NAME`** instead of `RELEASE_VERSION`. vanniktech then classifies the build as a snapshot and PUTs to the no-validation snapshot repo; no deployment bundle is created at all. `project.version` stays correct (`RELEASE_VERSION ?: VERSION_NAME`), so artifacts are still `X.Y.Z-SNAPSHOT`. Release workflows are untouched.

## Test plan
- [x] YAML validates.
- [x] Probe proves the repository URL flips to the snapshot endpoint under `VERSION_NAME`.
- [ ] After merge: `workflow_dispatch` `Publish Snapshot` on `main` → expect a plain snapshot PUT (no "Deployment" entry in the Portal) and `3.0.0-SNAPSHOT` available in the snapshot repo. Namespace SNAPSHOTs is already enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)