### PR TITLE
fix: parenthesize expiry predicate so it can't leak rows across stores (#67)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -133,7 +133,7 @@ class EntityQueries internal constructor(
                 )
                 if (expiresAt != null) add(
                     SqlQuery(
-                        where = "expires_at IS NULL OR expires_at >= ?",
+                        where = "(expires_at IS NULL OR expires_at >= ?)",
                         parameters = 1,
                         bindArgs = { bindLong(expiresAt.toEpochMilliseconds()) },
                     )
@@ -213,7 +213,7 @@ class EntityQueries internal constructor(
         )
         if (expiresAt != null) add(
             SqlQuery(
-                where = "expires_at IS NULL OR expires_at >= ?",
+                where = "(expires_at IS NULL OR expires_at >= ?)",
                 parameters = 1,
                 bindArgs = { bindLong(expiresAt.toEpochMilliseconds()) },
             )
@@ -493,7 +493,7 @@ class EntityQueries internal constructor(
                     ))
                 if (expiresAfter != null) add(
                     SqlQuery(
-                        where = "expires_at IS NULL OR expires_at >= ?",
+                        where = "(expires_at IS NULL OR expires_at >= ?)",
                         parameters = 1,
                         bindArgs = { bindLong(expiresAfter.toEpochMilliseconds()) }
                     )

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -534,8 +534,15 @@ internal fun List<SqlQuery>.buildFrom(prefix: String = ", ") = mapNotNull { it.f
     .joinToString(", ") { it }
     .let { if (it.isNotBlank()) "$prefix$it" else "" }
 
+// Each fragment is wrapped in parentheses so a fragment that contains a top-level OR
+// (e.g. the expiry predicate `expires_at IS NULL OR expires_at >= ?`) cannot bind loosely
+// against its AND-joined neighbours. Without the wrap, SQL's `AND`-over-`OR` precedence turns
+// `entity_name = ? AND expires_at IS NULL OR expires_at >= ?` into
+// `(entity_name = ? AND expires_at IS NULL) OR (expires_at >= ?)`, dropping the entity_name
+// scope from the second branch and leaking rows across stores. See #67.
 internal fun List<SqlQuery>.buildWhere(prefix: String = "WHERE") = mapNotNull { it.where }
-    .joinToString(" AND ") { it }
+    .filter { it.isNotBlank() }
+    .joinToString(" AND ") { "($it)" }
     .let { if (it.isNotBlank()) "$prefix $it" else "" }
 
 internal fun List<SqlQuery>.buildOrderBy(prefix: String = "ORDER BY") = mapNotNull { it.orderBy }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiryIsolationTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageExpiryIsolationTest.kt
@@ -1,0 +1,75 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Regression test for the cross-store expiry leak (#67).
+ *
+ * The expiry predicate `expires_at IS NULL OR expires_at >= ?` was appended to the WHERE
+ * fragment list un-parenthesized. `buildWhere` joins fragments with bare " AND ", and SQL
+ * `AND` binds tighter than `OR`, so the assembled clause parsed as
+ * `(entity_name = ? AND expires_at IS NULL) OR (expires_at >= ?)`. The `expires_at >= ?`
+ * branch was therefore no longer scoped to `entity_name`, and non-expired rows from *other*
+ * stores (which share the same driver/database) leaked into the result.
+ */
+class KeyValueStorageExpiryIsolationTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+
+    // Two stores backed by the same driver/database — the precondition for the leak.
+    private val storeA = keyValueStorage<TestObject>("store-a", entityQueries, metadataQueries, mainScope)
+    private val storeB = keyValueStorage<TestObject>("store-b", entityQueries, metadataQueries, mainScope)
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun selectWithExpiresAfter_doesNotLeakRowsFromOtherStore() = runTest {
+        val now = Clock.System.now()
+        // store B holds non-expired rows with a *non-null* future expiry — exactly the rows
+        // the un-parenthesized `OR expires_at >= ?` branch would leak into store A's query.
+        val bObjects = (0..4).map { TestObject() }.associateBy { it.id }
+        storeB.insertAll(bObjects, expiresAt = now.plus(1.hours))
+
+        val aObjects = (0..2).map { TestObject() }.associateBy { it.id }
+        storeA.insertAll(aObjects, expiresAt = now.plus(1.hours))
+
+        val result = storeA.selectAll(expiresAfter = now).first()
+
+        assertEquals(aObjects.keys, result.map { it.id }.toSet())
+    }
+
+    @Test
+    fun selectWithExpiresAfterAndWhere_doesNotLeakRowsFromOtherStore() = runTest {
+        val now = Clock.System.now()
+        val bObjects = (0..4).map { TestObject() }.associateBy { it.id }
+        storeB.insertAll(bObjects, expiresAt = now.plus(1.hours))
+
+        val aObjects = (0..2).map { TestObject() }.associateBy { it.id }
+        storeA.insertAll(aObjects, expiresAt = now.plus(1.hours))
+
+        // An additional user predicate that matches every row (names are random, so this
+        // constant never collides). With the broken precedence the leaking branch becomes
+        // `(expires_at >= ? AND <userWhere>)`, which B's rows also satisfy.
+        val result = storeA.select(
+            where = TestObject::name neq "__no_such_name__",
+            expiresAfter = now,
+        ).first()
+
+        assertEquals(aObjects.keys, result.map { it.id }.toSet())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a **store-isolation data leak** (P0). The expiry filter
`expires_at IS NULL OR expires_at >= ?` was appended to the WHERE fragment list
**un-parenthesized**. `buildWhere` joins fragments with bare ` AND `, and SQL's
`AND`-over-`OR` precedence turned

```
WHERE entity_name = ? AND expires_at IS NULL OR expires_at >= ?
```

into

```
WHERE (entity_name = ? AND expires_at IS NULL) OR (expires_at >= ?)
```

The `expires_at >= ?` branch was no longer scoped to `entity_name`. Because every
`sqkon.keyValueStore<T>(name)` shares one driver/database, a query on store A with
`expiresAfter` returned non-expired rows from stores B, C, … This is reachable via
the documented primary pattern `select(expiresAfter = Clock.System.now())` and
affected `select`, `selectByKeys`, `selectResult`, `count`, and keyset/offset paging.

## Fix

- **Root cause:** `buildWhere` now wraps every fragment in parentheses, so no
  fragment containing a top-level `OR` can bind loosely against its `AND`-joined
  neighbours.
- **Defense-in-depth:** the three expiry fragments are parenthesized at the source
  so they are self-contained regardless of how they are joined.

## Test plan (TDD)

- Added `KeyValueStorageExpiryIsolationTest` — written first, watched it **fail**
  (store B's rows leaked into store A), then fixed:
  - `selectWithExpiresAfter_doesNotLeakRowsFromOtherStore`
  - `selectWithExpiresAfterAndWhere_doesNotLeakRowsFromOtherStore` (with an extra
    user `where` predicate present)
- Full suite green: `./gradlew jvmTest` → **206 tests, 0 failures, 0 errors**
  (includes the `SchemaParityTest` + `SchemaMigrationTest` gate).

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
