### PR TITLE
fix: count(where=…) over-counts list/multi-match predicates (#68)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -501,8 +501,12 @@ class EntityQueries internal constructor(
                 addAll(listOfNotNull(where?.toSqlQuery(increment = 1)))
             }
             val identifier: Int = identifier("count", queries.identifier().toString())
+            // COUNT(DISTINCT entity.entity_key) — not COUNT(*). A json_tree join in the WHERE
+            // (list paths / inList / nested .then) yields one row per matching node, so COUNT(*)
+            // would count each match. entity_key is unique within an entity_name, so the DISTINCT
+            // count matches SelectQuery's `SELECT DISTINCT`. See #68.
             val sql = """
-                SELECT COUNT(*) FROM entity${queries.buildFrom()} ${queries.buildWhere()}
+                SELECT COUNT(DISTINCT entity.entity_key) FROM entity${queries.buildFrom()} ${queries.buildWhere()}
             """.trimIndent().replace('\n', ' ')
             return try {
                 driver.executeQuery(

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCountDistinctTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageCountDistinctTest.kt
@@ -1,0 +1,52 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for the count over-count bug (#68).
+ *
+ * `CountQuery` emitted `SELECT COUNT(*)` while `SelectQuery` uses `SELECT DISTINCT`. When the
+ * WHERE clause contains a `json_tree`-joined predicate that matches multiple nodes per entity
+ * (list paths / `inList` / nested `.then`), the join yields one row per matching node, so
+ * `COUNT(*)` counted each match. `count(where=p)` then disagreed with `select(where=p).size`.
+ */
+class KeyValueStorageCountDistinctTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope,
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun count_withListPredicateMatchingMultipleElements_matchesSelectSize() = runTest {
+        // A single entity whose list field has three elements, all matching the predicate.
+        // The json_tree join therefore produces three rows for this one entity.
+        val obj = TestObject(attributes = listOf("a", "b", "c"))
+        storage.insert(obj.id, obj)
+
+        val predicate = TestObject::attributes inList listOf("a", "b", "c")
+
+        val selectedSize = storage.select(where = predicate).first().size
+        val counted = storage.count(where = predicate).first()
+
+        // select() de-duplicates via DISTINCT — one matching entity.
+        assertEquals(1, selectedSize)
+        // count() must agree with select().size for the same predicate.
+        assertEquals(selectedSize, counted)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a correctness bug (P1): `count(where=…)` over-counted predicates that match
multiple JSON nodes per entity.

`CountQuery` emitted `SELECT COUNT(*)` while `SelectQuery` uses `SELECT DISTINCT`.
When the WHERE contains a `json_tree`-joined predicate that matches multiple nodes
per entity (list paths, `inList`, nested `.then`), the join yields one row per
matching node, so `COUNT(*)` counted each match. Result: `count(where=p)` and
`select(where=p).size` disagreed for the same predicate. `count(where=…)` is
public API returning `Flow<Int>`.

## Fix

`SELECT COUNT(DISTINCT entity.entity_key)`. `entity_key` is unique within an
`entity_name`, so the distinct count matches `SelectQuery`'s `DISTINCT` semantics.

## Test plan (TDD)

- Added `KeyValueStorageCountDistinctTest` — written first, watched it **fail**
  (`count` returned 3 for a single entity whose list field had 3 matching
  elements, while `select().size` was 1), then fixed.
- Full suite green: `./gradlew jvmTest` → **207 tests, 0 failures, 0 errors**.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)
