### PR TITLE
test: stabilize flaky externalTransaction (race on initial emission)

### DIFF
--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageTest.kt
@@ -663,6 +663,13 @@ class KeyValueStorageTest {
     @Test
     fun externalTransaction() = runTest {
         testObjectStorage.selectAll().test {
+            // Synchronize on the initial (empty) subscription emission before mutating.
+            // The original test ran the transaction before awaiting any item, so the initial
+            // emission raced the post-commit emission: the collector saw one item (fast
+            // machines, where the commit landed before the initial query emitted) or two
+            // (slower CI machines) — a flaky `ensureAllEventsConsumed`. Awaiting the initial
+            // empty state first removes the race.
+            assertEquals(0, awaitItem().size)
             testObjectStorage.transaction {
                 testObjectStorage.deleteAll()
                 testObjectStorage.insertAll(
@@ -671,7 +678,9 @@ class KeyValueStorageTest {
                         .toSortedMap()
                 )
             }
-            awaitItem()
+            // deleteAll + 101 inserts inside one transaction must coalesce into a single
+            // notification — exactly one further emission carrying all 101 rows.
+            assertEquals(101, awaitItem().size)
             ensureAllEventsConsumed()
         }
     }


### PR DESCRIPTION
## Summary

Fixes a **pre-existing flaky test** (`KeyValueStorageTest.externalTransaction`) that
intermittently fails CI's `jvm-tests` job. It surfaced while babysitting an unrelated
PR (#91), and — left unfixed — would block CI for every subsequent PR.

### Root cause

The test subscribed to `selectAll()` and then ran a transaction (`deleteAll` + 101
inserts) **before awaiting any item**. The initial (empty) subscription emission then
raced the post-commit emission:

- **Fast machines:** the synchronous transaction commits before the flow's initial
  query emits, so the collector sees a single item → passes.
- **Slower CI machines:** the initial empty emission arrives first, then the
  post-commit emission → two items. A single `awaitItem()` + `ensureAllEventsConsumed()`
  then fails with `TurbineAssertionError`.

### Fix

Await the initial empty emission first, then run the transaction, then assert exactly
one further emission of 101 rows. This removes the race **and** strengthens the
assertion that a transaction's writes coalesce into a single notification (the actual
contract the test name implies).

## Test plan

- Verified deterministic: **20/20** consecutive `cleanJvmTest` runs of the test pass,
  and the new `assertEquals(0, awaitItem().size)` never flaked (proving the initial
  emission is now ordered deterministically before the commit).
- Full suite green: `./gradlew jvmTest` → **206 tests, 0 failures, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
