### PR TITLE
fix: escape LIKE wildcards + match json_tree key quoting in fullkey predicates (#69)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -133,6 +133,40 @@ class JsonPathBuilder<R : Any>
     fun buildPath(): String {
         return fieldNames().joinToString("", prefix = "\$")
     }
+
+    /**
+     * Builds a pattern that matches the json_tree `fullkey` of the targeted node, for use as
+     * `fullkey LIKE ? ESCAPE '\'`. SQLite emits a key unquoted only when it is
+     * `[A-Za-z][A-Za-z0-9]*`; otherwise it double-quotes it (e.g. `$."user_name"`). We reproduce
+     * that quoting and escape LIKE metacharacters in the key, so a `_`/`%` in a field name is
+     * matched literally instead of acting as a wildcard (which previously leaked sibling keys —
+     * see #69). The `[%]` array token is left as a deliberate wildcard (match any index).
+     */
+    @OptIn(ExperimentalSerializationApi::class)
+    fun buildFullkeyPattern(): String {
+        return nodes().mapNotNull { node ->
+            if (node.receiverDescriptor.isInline) return@mapNotNull null // Skip inline classes
+            val keyPart = if (node.propertyName.isNotBlank()) ".${node.propertyName.toLikeFullkeyKey()}" else ""
+            when (node.valueDescriptor.kind) {
+                StructureKind.LIST -> "$keyPart[%]"
+                PolymorphicKind.SEALED -> "$keyPart[1]"
+                else -> keyPart
+            }
+        }.joinToString("", prefix = "\$")
+    }
+}
+
+/**
+ * SQLite json_tree emits a key in `fullkey` unquoted only when it matches `[A-Za-z][A-Za-z0-9]*`;
+ * any other key (snake_case, leading digit, `-`, space, …) is double-quoted. Reproduce that, and
+ * escape LIKE metacharacters (`\`, `%`, `_`) so they match literally under `ESCAPE '\'`. (#69)
+ */
+private fun String.toLikeFullkeyKey(): String {
+    val escaped = replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    val bareword = isNotEmpty() &&
+        (this[0] in 'a'..'z' || this[0] in 'A'..'Z') &&
+        all { it in 'a'..'z' || it in 'A'..'Z' || it in '0'..'9' }
+    return if (bareword) escaped else "\"$escaped\""
 }
 
 // Builder Methods to start building paths

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -75,10 +75,10 @@ data class Eq<T : Any, V>(
         val treeName = "eq_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value = ?)",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value = ?)",
             parameters = 2,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 bindValue(value)
             }
         )
@@ -121,10 +121,10 @@ data class NotEq<T : Any, V>(
         val treeName = "eq_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value != ?)",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value != ?)",
             parameters = 2,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 bindValue(value)
             }
         )
@@ -156,10 +156,10 @@ data class In<T : Any, V>(
         val treeName = "in_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value IN (${value.joinToString(",") { "?" }}))",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value IN (${value.joinToString(",") { "?" }}))",
             parameters = 1 + value.size,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 value.forEach { bindValue(it) }
             }
         )
@@ -176,10 +176,10 @@ data class NotIn<T : Any, V>(
         val treeName = "in_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value NOT IN (${value.joinToString(",") { "?" }}))",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value NOT IN (${value.joinToString(",") { "?" }}))",
             parameters = 1 + value.size,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 value.forEach { bindValue(it) }
             }
         )
@@ -224,10 +224,10 @@ data class Like<T : Any>(
         val treeName = "like_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value LIKE ?)",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value LIKE ?)",
             parameters = 2,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 bindString(value)
             }
         )
@@ -262,10 +262,10 @@ data class GreaterThan<T : Any, V>(
         val treeName = "gt_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value > ?)",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value > ?)",
             parameters = 2,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 bindValue(value)
             }
         )
@@ -299,10 +299,10 @@ data class LessThan<T : Any, V>(
         val treeName = "lt_$increment"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "($treeName.fullkey LIKE ? AND $treeName.value < ?)",
+            where = "($treeName.fullkey LIKE ? ESCAPE '\\' AND $treeName.value < ?)",
             parameters = 2,
             bindArgs = {
-                bindString(builder.buildPath())
+                bindString(builder.buildFullkeyPattern())
                 bindValue(value)
             }
         )
@@ -450,13 +450,13 @@ data class JsonPathOrderBy<T : Any> @PublishedApi internal constructor(
      */
     override val direction: OrderDirection? = null,
 ) : OrderBy<T>() {
-    private val path: String = builder.buildPath()
+    private val path: String = builder.buildFullkeyPattern()
 
     override fun toSqlQuery(index: Int): SqlQuery {
         val treeName = "order_$index"
         return SqlQuery(
             from = "json_tree(entity.value, '$') as $treeName",
-            where = "$treeName.fullkey LIKE ?",
+            where = "$treeName.fullkey LIKE ? ESCAPE '\\'",
             parameters = 1,
             bindArgs = { bindString(path) },
             orderBy = "$treeName.value ${direction?.value ?: ""}".trimEnd(),

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -180,3 +180,20 @@ data class NullableTestObject(
     val count: Int? = null,
     val flag: Boolean? = null,
 )
+
+/**
+ * A field whose JSON key contains `_` plus a sibling key that a LIKE wildcard would falsely
+ * match (the `_` matches any single char). Used by the fullkey-LIKE escaping regression (#69).
+ * The Kotlin property names are deliberately the JSON keys (no @SerialName), since the query
+ * path is built from the property name.
+ */
+@Suppress("PropertyName")
+@Serializable
+data class WildcardFieldObject(
+    val id: String,
+    val user_name: String,
+    val userXname: String,
+    // A list field whose key also needs quoting (json_tree emits `$."my_tags"[0]`), to cover the
+    // wildcard/quoting fix on list paths (the `[%]` array wildcard must survive).
+    val my_tags: List<String> = emptyList(),
+)

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CaseWhenSqlTest.kt
@@ -122,7 +122,7 @@ class CaseWhenSqlTest {
         val q = list.toSqlQueries().single()
 
         assertEquals("json_tree(entity.value, '\$') as order_0", q.from)
-        assertEquals("order_0.fullkey LIKE ?", q.where)
+        assertEquals("order_0.fullkey LIKE ? ESCAPE '\\'", q.where)
         assertEquals("order_0.value ASC", q.orderBy)
         assertEquals(1, q.parameters)
     }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonPathLikeEscapeTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonPathLikeEscapeTest.kt
@@ -1,0 +1,66 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.WildcardFieldObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for the `fullkey LIKE ?` wildcard bug (#69).
+ *
+ * Predicates match the JSON node with `<tree>.fullkey LIKE ?`, binding the built path
+ * (e.g. `$.user_name`) as the LIKE pattern. SQLite `LIKE` treats `_` as "any one char"
+ * (and `%` as "any sequence"), with no ESCAPE clause, so a query on a snake_case field like
+ * `user_name` also matched a sibling such as `userXname`. The fix escapes `_`/`%` in literal
+ * path segments (preserving the deliberate `[%]` array wildcard) and appends `ESCAPE '\'`.
+ */
+class JsonPathLikeEscapeTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<WildcardFieldObject>(
+        "wildcard-field", entityQueries, metadataQueries, mainScope,
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun eq_underscoreFieldName_doesNotMatchSiblingViaWildcard() = runTest {
+        // "bob" lives only in the sibling key `userXname`, never in `user_name`.
+        val obj = WildcardFieldObject(id = "1", user_name = "alice", userXname = "bob")
+        storage.insert(obj.id, obj)
+
+        // Querying user_name == "bob" must NOT match: the `_` in `$.user_name` was treated
+        // as a wildcard, so `fullkey LIKE '$.user_name'` also matched `$.userXname` (value "bob").
+        val falseMatch = storage.select(where = WildcardFieldObject::user_name eq "bob").first()
+        assertEquals(0, falseMatch.size)
+
+        // Sanity: the intended field still matches its real value.
+        val trueMatch = storage.select(where = WildcardFieldObject::user_name eq "alice").first()
+        assertEquals(1, trueMatch.size)
+    }
+
+    @Test
+    fun eq_underscoreListField_matchesElementDespiteFullkeyQuoting() = runTest {
+        // json_tree emits this element as `$."my_tags"[0]` (quoted key + index). The built
+        // pattern must reproduce the quoting, escape the `_`, and keep `[%]` as a wildcard,
+        // otherwise the list element never matches.
+        val obj = WildcardFieldObject(id = "1", user_name = "alice", userXname = "bob", my_tags = listOf("target"))
+        storage.insert(obj.id, obj)
+
+        val match = storage.select(where = WildcardFieldObject::my_tags eq "target").first()
+        assertEquals(1, match.size)
+
+        val noMatch = storage.select(where = WildcardFieldObject::my_tags eq "absent").first()
+        assertEquals(0, noMatch.size)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a correctness bug (P1) in JSON-field predicates. Two interacting problems were
found while reproducing the issue against SQLite:

1. **LIKE wildcards** — predicates (`eq/neq/in/notIn/like/gt/lt`) and `JsonPathOrderBy`
   match the node with `<tree>.fullkey LIKE ?` and bind the built path as the pattern.
   SQLite `LIKE` treats `_` as "any one char" and `%` as "any sequence", with no
   `ESCAPE`. So a query on a snake_case field like `user_name` also matched a sibling
   such as `userXname` (`'$.userXname' LIKE '$.user_name'` → 1).

2. **json_tree key quoting** (discovered while fixing #1) — json_tree's `fullkey`
   double-quotes any key that is not `[A-Za-z][A-Za-z0-9]*`:
   `$."user_name"`, `$."my_tags"[0]`. But the built path emitted `$.user_name`, so
   underscore/special keys **never matched the real node** — they only ever matched
   *unquoted* sibling keys via the `_` wildcard. Escaping alone would kill the false
   match but leave the real field unmatched, so the quoting must be reproduced too.

## Fix

- Add `JsonPathBuilder.buildFullkeyPattern()`: reproduces json_tree's per-key quoting
  rule and escapes LIKE metacharacters (`\`, `_`, `%`) in each key segment, while
  leaving the deliberate `[%]` array-index wildcard intact.
- Emit `fullkey LIKE ? ESCAPE '\'` at all predicate and order-by sites.
- `json_extract`-based scalar lowering is untouched — it parses the path itself and
  tolerates unquoted keys.

## Test plan (TDD)

- Added `JsonPathLikeEscapeTest` — written first, watched it fail:
  - scalar snake_case field `user_name` must not match sibling `userXname`, and must
    still match its own value;
  - underscore **list** field `my_tags` must match its element despite `fullkey`
    quoting (`$."my_tags"[0]`).
- Updated the order-by SQL-string assertion to include `ESCAPE '\'`.
- Full suite green: `./gradlew jvmTest` → **208 tests, 0 failures, 0 errors**. Existing
  queries (camelCase/bareword keys) are unaffected — those keys aren't quoted and have
  no LIKE metacharacters.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
