### PR TITLE
docs: correct write-threading claim — writes block the caller thread (#70)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -93,12 +93,25 @@ val merchants: KeyValueStorage<Merchant> =
 
 ## 4. Insert, update, and delete
 
-Write methods are blocking transactions on the calling thread (not `suspend`),
-but they're cheap — Sqkon dispatches the SQLite work onto its internal
-write dispatcher under the hood. You can call them from any context, but for
-UI threads on Android you'll typically still wrap them in
-`launch { ... }` / `withContext(...)` to keep the calling site uniformly
-async with the rest of your code.
+Every method that mutates the store — the `insert*`, `update`, `upsert`, and
+`delete*` families (including `deleteAll`, `deleteByKey(s)`, `deleteExpired`,
+`deleteStale`) — is a **blocking transaction that runs the SQLite work
+synchronously on the calling thread**; none of them are `suspend`. Only the
+follow-up metadata bookkeeping (read/write timestamps) is dispatched onto Sqkon's
+internal write dispatcher; the write itself happens inline on your thread.
+
+So you must keep writes **off the Android main thread** yourself — wrap them in
+`withContext(Dispatchers.IO) { ... }` (or call them from a background dispatcher)
+to avoid blocking the UI and triggering ANRs:
+
+```kotlin
+withContext(Dispatchers.IO) {
+    merchants.insert(key = chipotle.id, value = chipotle)
+}
+```
+
+Reads (`select*` / `count` / `metadata`) return `Flow`s and are already dispatched
+onto Sqkon's internal read dispatcher, so those you can collect from any context.
 
 ```kotlin
 val chipotle = Merchant(id = "1", name = "Chipotle", category = "Food")

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,8 @@ data class Merchant(
 val sqkon = Sqkon(context = applicationContext, scope = appScope)
 val merchants = sqkon.keyValueStorage<Merchant>("merchants")
 
-// Insert (sync) — Sqkon dispatches the SQLite work internally.
+// Insert (sync) — runs the SQLite write inline on the calling thread, so keep
+// writes off the Android main thread (e.g. withContext(Dispatchers.IO) { ... }).
 merchants.insert("m_1", Merchant("m_1", "Chipotle", "Food"))
 
 // Observe — emits whenever the store changes. Collect from a coroutine.


### PR DESCRIPTION
## Summary

Fixes a **dangerous documentation claim** (P1). The quickstart and home page stated:

> Write methods are blocking transactions on the calling thread … Sqkon dispatches the
> SQLite work onto its internal write dispatcher under the hood. You can call them from
> any context.

That's false. `insert/update/upsert/delete/deleteExpired/deleteStale` acquire the writer
mutex (`sqkonRunBlocking { writerMutex.lock() }`) and run the SQLite transaction
**synchronously on the caller's thread**. The write dispatcher is used only for the
fire-and-forget metadata bookkeeping (`updateReadAt` / `updateWriteAt`'s `afterCommit`),
never the entity write. Reads, by contrast, *are* dispatched. A consumer trusting the old
text would call `insert()` on the Android main thread and block on SQLite I/O → jank / ANR.

## Fix (the ticket's "Immediate" option)

- `docs/getting-started/quickstart.md`: scope the dispatch claim to reads; state writes run
  inline on the caller's thread and must be moved off the UI thread (`withContext(Dispatchers.IO)`),
  with an example.
- `docs/index.md`: correct the inline `// Insert (sync)` comment.

## Decision recorded — 3.0 `suspend` writes (acceptance criterion #2)

The **structural** option — making the write methods `suspend` and routing through
`withContext(writeDispatcher)` so blocking happens on the dedicated single-thread write
dispatcher rather than arbitrary caller threads — is a **breaking API change** and is
**not** done here. Recommendation, deferred to a 3.0 major bump (owner's call, since
release-please drives semver):

- Make `insert/insertAll/update/upsert/delete/deleteExpired/deleteStale` `suspend` and wrap
  their bodies in `withContext(writeDispatcher)`.
- This also resolves the thread-confinement caveat noted in the author's TODO at
  `KeyValueStorage.kt` (ThreadLocal transaction tracking + back-to-back suspending calls).

Until then, the corrected docs make the current contract explicit.

## Test plan

Docs-only change — no code paths touched. CI (`jvmTest` + Android + iOS compile) runs as a
regression guard.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
