### PR TITLE
fix: bind Float query values as reals instead of truncating to Long (#72)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -676,6 +676,9 @@ class AutoIncrementSqlPreparedStatement internal constructor(
             is Boolean -> bindBoolean(value)
             is ByteArray -> bindBytes(value)
             is Double -> bindDouble(value)
+            // Float must bind as a real, not fall into the generic Number branch below, which
+            // would truncate it to a Long (`gt 1.9f` -> 1, `eq 1.5f` -> 1). See #72.
+            is Float -> bindDouble(value.toDouble())
             is Number -> bindLong(value.toLong())
             is String -> bindString(value)
             is Enum<*> -> {

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/TestDataClasses.kt
@@ -181,6 +181,13 @@ data class NullableTestObject(
     val flag: Boolean? = null,
 )
 
+/** A `Float` field for binding-coercion coverage (#72): fractional values must not truncate. */
+@Serializable
+data class FloatFieldObject(
+    val id: String,
+    val price: Float,
+)
+
 /**
  * A field whose JSON key contains `_` plus a sibling key that a LIKE wildcard would falsely
  * match (the `_` matches any single char). Used by the fullkey-LIKE escaping regression (#69).

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonPathFloatBindingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/JsonPathFloatBindingTest.kt
@@ -1,0 +1,51 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.FloatFieldObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for Float query-value truncation (#72).
+ *
+ * `bindValue` handled `is Double`, then caught every other `Number` via
+ * `is Number -> bindLong(value.toLong())`, so a `Float` query value was silently truncated to a
+ * `Long` (`gt 1.9f` bound `1`, `eq 1.5f` bound `1`) — wrong results, no error.
+ */
+class JsonPathFloatBindingTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<FloatFieldObject>(
+        "float-field", entityQueries, metadataQueries, mainScope,
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun gt_floatField_comparesAtFractionalBoundary() = runTest {
+        storage.insert("1", FloatFieldObject(id = "1", price = 1.5f))
+
+        // 1.5 is not > 1.9. Before the fix `gt 1.9f` bound 1L, so `1.5 > 1` matched (wrong).
+        assertEquals(0, storage.select(where = FloatFieldObject::price gt 1.9f).first().size)
+        // 1.5 is > 1.0.
+        assertEquals(1, storage.select(where = FloatFieldObject::price gt 1.0f).first().size)
+    }
+
+    @Test
+    fun eq_floatField_matchesFractionalValue() = runTest {
+        storage.insert("1", FloatFieldObject(id = "1", price = 1.5f))
+
+        // Before the fix `eq 1.5f` bound 1L and never matched the stored 1.5.
+        assertEquals(1, storage.select(where = FloatFieldObject::price eq 1.5f).first().size)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes silent wrong results (P2) when querying `Float` fields. `bindValue` handled `is Double`,
then caught every other `Number` via `is Number -> bindLong(value.toLong())`, so a `Float` query
value was silently truncated to a `Long`:

- `price gt 1.9f` bound `1` → `value > 1` (matched 1.5, wrong)
- `price eq 1.5f` bound `1` → never matched the stored `1.5`

No exception — just wrong results. kotlinx.serialization stores `Float` fields as JSON reals, so
this is reachable.

## Fix

Add `is Float -> bindDouble(value.toDouble())` before the generic `Number` branch in
`QueryExt.kt`. Integral `Number` types still bind as `Long`. `BigDecimal`/`BigInteger` are
JVM-only types not referenceable from `commonMain`, so they remain out of scope of this common fix
(noted for a future platform-specific pass).

## Test plan (TDD)

- Added `JsonPathFloatBindingTest` — written first, watched both cases fail:
  - `gt 1.9f` on a stored `1.5` returns 0 (not 1); `gt 1.0f` returns 1.
  - `eq 1.5f` matches the stored `1.5`.
- Full suite green: `./gradlew jvmTest` → **215 tests, 0 failures, 0 errors**.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
