### PR TITLE
docs: document the enum @SerialName query gap accurately + drop dead code (#73)

### DIFF
--- a/docs/guides/querying.md
+++ b/docs/guides/querying.md
@@ -408,10 +408,25 @@ type you give it, and the JSON value is a string.
 
 ### Enums
 
-Enums bind by **Kotlin name** (the default `kotlinx.serialization`
-representation). `@SerialName` on enum constants is not yet honored at the
-binding layer (see the comment in `QueryExt.kt`'s `bindValue`). If you renamed
-an enum case with `@SerialName`, query against the original name for now.
+Enums bind by their **Kotlin constant name** (`Status.ACTIVE` binds `"ACTIVE"`),
+not by `@SerialName`. But kotlinx.serialization *stores* an enum using its
+`@SerialName` when present, so for a constant that has `@SerialName` the typed
+overload silently fails to match — it binds the constant name while the stored
+value is the serial name. Query the serial-name **string** instead:
+
+```kotlin
+enum class Status { @SerialName("active") ACTIVE, ARCHIVED }
+
+// Stored as "active", but `eq Status.ACTIVE` binds "ACTIVE" → no rows:
+store.select(where = MyType::status eq Status.ACTIVE)   // ✗ silently empty
+
+// Work around it by querying the serial-name string directly:
+store.select(where = MyType::status eq "active")        // ✓ matches
+```
+
+Constants without `@SerialName` (e.g. `ARCHIVED` above) work with the typed
+overload as expected. Honoring `@SerialName` on the typed overload requires
+encoding the value through its serializer at the call site; tracked in #11.
 
 ### Performance and entity scoping
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/QueryExt.kt
@@ -95,7 +95,11 @@ infix fun <T : Any, V> JsonPathBuilder<T>.eq(value: V?): Eq<T, V> =
     Eq(builder = this, value = value)
 
 /**
- * Equivalent to `=` in SQL
+ * Equivalent to `=` in SQL.
+ *
+ * Note: enum values bind by their Kotlin constant name, **not** `@SerialName`. For a constant
+ * annotated with `@SerialName`, pass the serial-name string instead (e.g. `eq "active"`) — the
+ * typed enum form would silently not match. See the Querying guide and #11.
  */
 inline infix fun <reified T : Any, reified V, VALUE> KProperty1<T, V>.eq(value: VALUE?): Eq<T, VALUE> =
     Eq(this.builder(), value)
@@ -682,13 +686,15 @@ class AutoIncrementSqlPreparedStatement internal constructor(
             is Number -> bindLong(value.toLong())
             is String -> bindString(value)
             is Enum<*> -> {
-                // Doesn't support @SerialName for now https://github.com/Kotlin/kotlinx.serialization/issues/2956
-//                val e = value as T
-//                e::class.serializerOrNull()?.let {
-//                    val sName = it.descriptor.getElementDescriptor(value.ordinal).serialName
-//                    bindString(sName)
-//                } ?: bindString(null)
-                bindString(value.name) // use ordinal name for now (which is default serialization)
+                // Binds the Kotlin constant name. @SerialName on enum constants is NOT honored
+                // here: the value reaches this point type-erased, and the serial name is not
+                // exposed on the enum's SerialDescriptor — `getElementName(ordinal)` returns the
+                // constant name (kotlinx.serialization #2956), so the serial name is only
+                // observable by actually encoding the value through its serializer (which needs a
+                // reified type + Json instance the DSL layer doesn't have). Querying a constant
+                // that has @SerialName therefore silently fails to match the stored value; pass
+                // the serial-name string instead (e.g. `eq "active"`). Tracked in #11/#73.
+                bindString(value.name)
             }
 
             null -> bindString(null)

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEnumTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEnumTest.kt
@@ -55,7 +55,10 @@ class KeyValueStorageEnumTest {
         val bySecondEnum = testObjectStorage.select(
             where = TestObject::testEnum eq TestEnum.SECOND,
         ).first()
-        // Broken due to lack of serialName support from descriptors
+        // @SerialName on enum constants is not honored by the typed `eq` overload (it binds the
+        // Kotlin constant name "LAST", while the stored value is the serial name "unknown"), so the
+        // documented workaround is to query the serial-name string directly. See #73 and
+        // docs/guides/querying.md (### Enums).
         val byLastEnum = testObjectStorage.select(
             where = TestObject::testEnum eq "unknown",
         ).first()


### PR DESCRIPTION
## Summary

Resolves the enum `@SerialName` query footgun (P2) via accurate documentation — the ticket's
sanctioned alternative — after confirming a clean code fix isn't available at this layer.

`eq` / `whenEq` bind an enum by its **Kotlin constant name**, but kotlinx.serialization *stores*
enums using `@SerialName` when present. So querying a constant that has `@SerialName` silently
returns zero matches.

### Why not the "resolve from descriptor" fix the ticket suggested

I verified empirically: `serializer<E>().descriptor.getElementName(ordinal)` returns the **constant
name** (`LAST`), **not** the serial name (`unknown`) — this is kotlinx.serialization
[#2956](https://github.com/Kotlin/kotlinx.serialization/issues/2956). The serial name is only
observable by *encoding* the value through its serializer, which needs a reified type + a `Json`
instance the pure DSL layer doesn't have. A correct fix belongs to the enum-query redesign tracked
in #11.

## Changes

- **`docs/guides/querying.md` (### Enums)** — the previous text told users to "query against the
  original name," which is **wrong**: the constant name never matches the stored serial name.
  Corrected to show the real workaround (`eq "active"`) with a worked example, and clarified that
  constants without `@SerialName` work fine with the typed overload.
- **`bindValue`** — replaced the stale, commented-out (and non-working) descriptor attempt with an
  accurate explanation of why `@SerialName` can't be honored here.
- **`eq` operator KDoc** — added a concise note.
- **`select_bySerialNameEnum` test** — corrected the comment to explain the documented workaround.

## Test plan

Documentation / comment changes only — no runtime behavior change. Full suite green:
`./gradlew jvmTest` → **215 tests, 0 failures, 0 errors**. The existing `select_bySerialNameEnum`
test continues to lock in the documented workaround.

Closes #73 (deeper typed-enum support tracked in #11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
