### PR TITLE
fix: verify SQL on statement-cache hit to guard against identifier collisions (#74)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/AndroidxStatement.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/AndroidxStatement.kt
@@ -14,6 +14,12 @@ import com.mercury.sqkon.db.internal.SqkonStatement
  */
 internal sealed class AndroidxStatement(
     protected val statement: SQLiteStatement,
+    /**
+     * The SQL this statement was prepared from. The statement cache is keyed by a 32-bit
+     * identifier hash, so a hash collision could hand back a statement prepared from different
+     * SQL; callers compare [sql] on a cache hit to guard against that. See #74.
+     */
+    val sql: String,
 ) : SqkonStatement {
     override fun bindBytes(index: Int, value: ByteArray?) {
         if (value == null) statement.bindNull(index + 1) else statement.bindBlob(index + 1, value)
@@ -37,12 +43,12 @@ internal sealed class AndroidxStatement(
 }
 
 /** DML/DDL — no rows. Caller invokes [execute] after binding. */
-internal class AndroidxPreparedStatement(statement: SQLiteStatement) : AndroidxStatement(statement) {
+internal class AndroidxPreparedStatement(statement: SQLiteStatement, sql: String) : AndroidxStatement(statement, sql) {
     /** Step the statement to completion. */
     fun execute() { while (statement.step()) { /* drain */ } }
 }
 
 /** SELECT — caller invokes [executeQuery] after binding to map the cursor. */
-internal class AndroidxQuery(statement: SQLiteStatement) : AndroidxStatement(statement) {
+internal class AndroidxQuery(statement: SQLiteStatement, sql: String) : AndroidxStatement(statement, sql) {
     fun <R> executeQuery(mapper: (SqkonCursor) -> R): R = mapper(AndroidxSqkonCursor(statement))
 }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/SqkonStatementCache.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/SqkonStatementCache.kt
@@ -39,19 +39,19 @@ internal class SqkonStatementCache(private val config: SqkonDriverConfig) {
         binders: (SqkonStatement.() -> Unit)?,
     ) {
         if (identifier == null) {
-            val stmt = AndroidxPreparedStatement(connection.prepare(sql))
+            val stmt = AndroidxPreparedStatement(connection.prepare(sql), sql)
             try { binders?.invoke(stmt); stmt.execute() } finally { stmt.close() }
             return
         }
         val cache = lookupCache(connection)
         val claimed = sqkonRunBlocking { mapMutex.withLock { cache.remove(identifier) } }
-        val stmt: AndroidxPreparedStatement = if (claimed is AndroidxPreparedStatement) {
+        val stmt: AndroidxPreparedStatement = if (claimed is AndroidxPreparedStatement && claimed.sql == sql) {
             claimed
         } else {
-            // Wrong subtype (collision with a query cached under same identifier) — close it so
-            // we don't leak the SQLiteStatement.
+            // Wrong subtype, or an identifier-hash collision against different SQL — close the
+            // claimed statement (if any) so we don't leak it, and prepare the correct SQL. See #74.
             claimed?.close()
-            AndroidxPreparedStatement(connection.prepare(sql))
+            AndroidxPreparedStatement(connection.prepare(sql), sql)
         }
         try {
             binders?.invoke(stmt)
@@ -72,7 +72,7 @@ internal class SqkonStatementCache(private val config: SqkonDriverConfig) {
         mapper: (SqkonCursor) -> R,
     ): R {
         if (identifier == null) {
-            val stmt = AndroidxQuery(connection.prepare(sql))
+            val stmt = AndroidxQuery(connection.prepare(sql), sql)
             try {
                 binders?.invoke(stmt)
                 return stmt.executeQuery(mapper)
@@ -80,11 +80,13 @@ internal class SqkonStatementCache(private val config: SqkonDriverConfig) {
         }
         val cache = lookupCache(connection)
         val claimed = sqkonRunBlocking { mapMutex.withLock { cache.remove(identifier) } }
-        val stmt: AndroidxQuery = if (claimed is AndroidxQuery) {
+        val stmt: AndroidxQuery = if (claimed is AndroidxQuery && claimed.sql == sql) {
             claimed
         } else {
+            // Wrong subtype, or an identifier-hash collision against different SQL — close the
+            // claimed statement (if any) so we don't leak it, and prepare the correct SQL. See #74.
             claimed?.close()
-            AndroidxQuery(connection.prepare(sql))
+            AndroidxQuery(connection.prepare(sql), sql)
         }
         try {
             binders?.invoke(stmt)

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonStatementCacheTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonStatementCacheTest.kt
@@ -1,0 +1,68 @@
+package com.mercury.sqkon.db
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_CREATE
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_FULLMUTEX
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_READWRITE
+import com.mercury.sqkon.db.internal.androidx.SqkonStatementCache
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for the statement-cache identifier-collision bug (#74).
+ *
+ * The cache is keyed by a 32-bit `identifier` (a hashCode of the runtime-variable query shape).
+ * On a cache hit it reused the cached statement when only the identifier + subtype matched, without
+ * checking the SQL — so a collision between two structurally different same-subtype queries would
+ * execute the wrong prepared statement. The fix compares the cached statement's SQL on a hit.
+ */
+class SqkonStatementCacheTest {
+
+    private fun memoryConnection(): SQLiteConnection =
+        BundledSQLiteDriver().open(
+            ":memory:", SQLITE_OPEN_READWRITE or SQLITE_OPEN_CREATE or SQLITE_OPEN_FULLMUTEX,
+        )
+
+    @Test
+    fun sameIdentifierDifferentSql_doesNotReuseStaleStatement() {
+        val cache = SqkonStatementCache(SqkonDriverConfig())
+        val conn = memoryConnection()
+        try {
+            // Cache a statement for "SELECT 1" under identifier 42.
+            val r1 = cache.executeQuery(conn, identifier = 42, sql = "SELECT 1", binders = null) { c ->
+                c.next(); c.getLong(0)
+            }
+            assertEquals(1L, r1)
+
+            // Same identifier (simulating a hashCode collision) but DIFFERENT SQL. The cache must
+            // NOT reuse the cached "SELECT 1" statement — it must prepare "SELECT 2".
+            val r2 = cache.executeQuery(conn, identifier = 42, sql = "SELECT 2", binders = null) { c ->
+                c.next(); c.getLong(0)
+            }
+            assertEquals(2L, r2)
+        } finally {
+            cache.evictAll() // close cached statements before the connection
+            conn.close()
+        }
+    }
+
+    @Test
+    fun sameIdentifierSameSql_reusesStatementAndReturnsCorrectResults() {
+        val cache = SqkonStatementCache(SqkonDriverConfig())
+        val conn = memoryConnection()
+        try {
+            // Repeated identical (identifier, sql) must keep returning the right result while
+            // exercising the reuse path (no collision).
+            repeat(3) {
+                val r = cache.executeQuery(conn, identifier = 7, sql = "SELECT 5", binders = null) { c ->
+                    c.next(); c.getLong(0)
+                }
+                assertEquals(5L, r)
+            }
+        } finally {
+            cache.evictAll() // close cached statements before the connection
+            conn.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a latent silent-wrong-results bug (P2) in the per-connection prepared-statement cache.

The cache is keyed by a 32-bit `Int` identifier — a `hashCode` of the **runtime-variable** query
shape (`SqlQuery.identifier` folds from/where/orderBy hashCodes). On a cache hit it reused the
cached statement whenever the identifier **and subtype** matched, **without ever comparing the
cached statement's SQL** to the current SQL. Unlike SQLDelight (compile-time-unique ids), these are
runtime hashes of user-driven query shapes, so a collision between two structurally different
same-subtype queries would bind the current call's params into the **wrong** prepared statement.

## Fix

Store the originating `sql` on `AndroidxStatement` and require `claimed.sql == sql` on a cache hit.
On a mismatch (collision) or wrong subtype, close the claimed statement (no leak) and prepare the
correct SQL. A cheap equality guard removes the failure mode.

## Test plan (TDD)

- Added `SqkonStatementCacheTest`:
  - `sameIdentifierDifferentSql_doesNotReuseStaleStatement` — two queries under the **same**
    identifier but different SQL (`SELECT 1` / `SELECT 2`) must each return their own result.
  - `sameIdentifierSameSql_reusesStatementAndReturnsCorrectResults` — repeated identical
    `(identifier, sql)` reuse stays correct.
- **Teeth verified:** removing the `&& claimed.sql == sql` guard makes the collision test fail
  (it reuses the stale `SELECT 1` statement and returns `1` for `SELECT 2`).
- Full suite green: `./gradlew jvmTest` → **217 tests, 0 failures, 0 errors**.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
