### PR TITLE
fix: set PRAGMA busy_timeout on every connection (WAL contention hardening) (#75)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDriverConfig.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/SqkonDriverConfig.kt
@@ -20,8 +20,10 @@ enum class SqkonSync(internal val pragma: String) {
 
 /**
  * Tunables for the native androidx.sqlite-backed driver. Defaults match the pre-3.0 behavior
- * (WAL, NORMAL, 4 reader connections), except every connection now opens with
- * `SQLITE_OPEN_FULLMUTEX` on JVM too (previously implicit only on Android).
+ * (WAL, NORMAL, 4 reader connections), with two intentional differences: every connection now
+ * opens with `SQLITE_OPEN_FULLMUTEX` on JVM too (previously implicit only on Android), and a
+ * non-zero `busy_timeout` (3000 ms) is applied for WAL-contention hardening (was SQLite's
+ * fail-immediately default of 0).
  */
 class SqkonDriverConfig(
     val journalMode: SqkonJournalMode = SqkonJournalMode.WAL,
@@ -30,4 +32,11 @@ class SqkonDriverConfig(
     val readerConnections: Int = 4,
     /** Per-connection prepared-statement LRU size. */
     val statementCacheSize: Int = 25,
+    /**
+     * `PRAGMA busy_timeout` in milliseconds, applied to every connection. Standard WAL hardening:
+     * under WAL a writer can transiently hit `SQLITE_BUSY` during checkpoint, and a second
+     * driver/process on the same file fails `BEGIN IMMEDIATE` immediately without it. Set to `0`
+     * to use SQLite's default (fail immediately, no wait).
+     */
+    val busyTimeoutMillis: Long = 3_000,
 )

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/SqkonConnectionPool.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/SqkonConnectionPool.kt
@@ -39,6 +39,9 @@ internal class SqkonConnectionPool(
     private fun applyPragmas(c: SQLiteConnection) {
         c.execSQL("PRAGMA journal_mode = ${config.journalMode.pragma};")
         c.execSQL("PRAGMA synchronous = ${config.sync.pragma};")
+        // WAL hardening: wait (rather than failing immediately with SQLITE_BUSY) for transient
+        // checkpoint / multi-connection / multi-process write contention. See #75.
+        c.execSQL("PRAGMA busy_timeout = ${config.busyTimeoutMillis};")
     }
 
     fun acquireWriter(): SQLiteConnection {

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonBusyTimeoutTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SqkonBusyTimeoutTest.kt
@@ -1,0 +1,64 @@
+package com.mercury.sqkon.db
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_CREATE
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_FULLMUTEX
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_READWRITE
+import com.mercury.sqkon.db.internal.androidx.SqkonConnectionFactory
+import com.mercury.sqkon.db.internal.androidx.SqkonConnectionPool
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for the missing `busy_timeout` (#75). `applyPragmas` set only `journal_mode`
+ * and `synchronous`, so every connection used SQLite's default `busy_timeout = 0` — any transient
+ * WAL/checkpoint/multi-process contention failed `BEGIN IMMEDIATE` with `SQLITE_BUSY` immediately.
+ */
+class SqkonBusyTimeoutTest {
+
+    private fun tempDbPath(): String =
+        File.createTempFile("sqkon-busy-", ".db").also { it.delete(); it.deleteOnExit() }.absolutePath
+
+    private fun factory(path: String) = SqkonConnectionFactory {
+        BundledSQLiteDriver().open(path, SQLITE_OPEN_READWRITE or SQLITE_OPEN_CREATE or SQLITE_OPEN_FULLMUTEX)
+    }
+
+    private fun readBusyTimeout(conn: SQLiteConnection): Long =
+        conn.prepare("PRAGMA busy_timeout").use { st -> st.step(); st.getLong(0) }
+
+    /** Reads busy_timeout off the writer connection, always releasing the writer mutex. */
+    private fun busyTimeoutOf(pool: SqkonConnectionPool): Long {
+        val conn = pool.acquireWriter()
+        try {
+            return readBusyTimeout(conn)
+        } finally {
+            pool.releaseWriter()
+        }
+    }
+
+    @Test
+    fun busyTimeout_defaultsToConfiguredValue() {
+        val path = tempDbPath()
+        val pool = SqkonConnectionPool(factory(path), path, isMemory = false, config = SqkonDriverConfig())
+        try {
+            assertEquals(3_000L, busyTimeoutOf(pool))
+        } finally {
+            pool.close()
+        }
+    }
+
+    @Test
+    fun busyTimeout_honorsCustomConfig() {
+        val path = tempDbPath()
+        val pool = SqkonConnectionPool(
+            factory(path), path, isMemory = false, config = SqkonDriverConfig(busyTimeoutMillis = 1234),
+        )
+        try {
+            assertEquals(1234L, busyTimeoutOf(pool))
+        } finally {
+            pool.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a robustness gap (P2): no `busy_timeout` was configured, so transient WAL contention became
a hard error.

`applyPragmas` set only `journal_mode` and `synchronous`, leaving SQLite's default
`busy_timeout = 0`. The driver issues `BEGIN IMMEDIATE` (RESERVED lock), so under WAL a writer that
hits `SQLITE_BUSY` during checkpoint — or any second driver/process on the same file — failed
immediately instead of briefly waiting. The single writer `Mutex` only serializes writers within
one driver instance.

## Fix

- Add `busyTimeoutMillis` to `SqkonDriverConfig` (default **3000 ms**; `0` keeps SQLite's
  fail-immediately default).
- Apply `PRAGMA busy_timeout` to every connection in `applyPragmas`. Standard WAL hardening,
  matching SQLDelight/AndroidX defaults.

## Test plan (TDD)

- Added `SqkonBusyTimeoutTest` — written first, watched it fail (`busy_timeout` was `0`):
  - default config applies `3000`;
  - a custom `busyTimeoutMillis = 1234` is honored.
  Both read the value back via `PRAGMA busy_timeout` on a file-backed connection.
- Full suite green: `./gradlew jvmTest` → **219 tests, 0 failures, 0 errors**.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
