### PR TITLE
fix: guard ListenerIdentityMap with a Mutex for concurrent Flow collectors (#76)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/ListenerIdentityMap.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/ListenerIdentityMap.kt
@@ -1,26 +1,32 @@
 package com.mercury.sqkon.db.internal
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
 /**
  * Maintains an identity map between a Sqkon listener and a delegate listener so
  * `removeListener` can find the same delegate instance the underlying driver
- * registered. Used by the three places that bridge SQLDelight listeners to
- * Sqkon listeners (driver, query, EntityQueries inner classes).
+ * registered. Used by `DriverBackedSqkonQuery` to bridge `SqkonQuery.Listener`s to
+ * `SqkonDriver.Listener`s.
  *
- * Not thread-safe — listener registration is expected single-threaded per query
- * (mirrors SQLDelight's `Query` contract).
+ * Thread-safe: `asFlow()` (callbackFlow) calls [add] on collection start and [remove] in
+ * `awaitClose` on arbitrary dispatchers, so a cold Flow collected by multiple coroutines mutates
+ * one map concurrently. The map mutation is guarded by a [Mutex]; the register/unregister callback
+ * runs outside the lock (it calls into the driver and must not re-enter the lock). See #76.
  */
 internal class ListenerIdentityMap<K : Any, V : Any>(
     private val factory: (K) -> V,
 ) {
     private val map = mutableMapOf<K, V>()
+    private val mutex = Mutex()
 
     fun add(key: K, register: (V) -> Unit) {
-        val delegate = map.getOrPut(key) { factory(key) }
+        val delegate = sqkonRunBlocking { mutex.withLock { map.getOrPut(key) { factory(key) } } }
         register(delegate)
     }
 
     fun remove(key: K, unregister: (V) -> Unit) {
-        val delegate = map.remove(key) ?: return
+        val delegate = sqkonRunBlocking { mutex.withLock { map.remove(key) } } ?: return
         unregister(delegate)
     }
 }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/ListenerIdentityMapTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/ListenerIdentityMapTest.kt
@@ -1,0 +1,57 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.db.internal.ListenerIdentityMap
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for the unsynchronized ListenerIdentityMap (#76).
+ *
+ * `DriverBackedSqkonQuery` owns one map per query, and `asFlow()` (callbackFlow) calls
+ * `add` on collection start / `remove` in `awaitClose` on arbitrary dispatchers, so a cold Flow
+ * collected by multiple coroutines mutates the shared map concurrently. With a plain
+ * `mutableMapOf`, concurrent `getOrPut` for the same key races: the factory runs more than once
+ * and the surplus delegate is registered with the driver but never stored, so it can never be
+ * removed (a listener leak).
+ */
+class ListenerIdentityMapTest {
+
+    @Test
+    fun concurrentAdd_sameKey_runsFactoryExactlyOnce() {
+        // Repeat to make the race reliably observable on the unsynchronized map.
+        repeat(50) { round ->
+            val factoryCalls = AtomicInteger(0)
+            val map = ListenerIdentityMap<Int, Any>(factory = { factoryCalls.incrementAndGet(); Any() })
+            val threadCount = 16
+            val barrier = CyclicBarrier(threadCount)
+            val registered = CopyOnWriteArrayList<Any>()
+            val errors = CopyOnWriteArrayList<Throwable>()
+
+            (0 until threadCount).map {
+                thread {
+                    try {
+                        barrier.await() // all threads hit add() for the same key simultaneously
+                        map.add(round) { delegate -> registered += delegate }
+                    } catch (e: Throwable) {
+                        errors += e
+                    }
+                }
+            }.forEach { it.join() }
+
+            // Worker threads swallow their own exceptions otherwise — surface them here.
+            assertTrue(errors.isEmpty(), "worker threw in round $round: ${errors.firstOrNull()}")
+            // Every worker must have run its register callback.
+            assertEquals(threadCount, registered.size, "not every worker registered in round $round")
+            // The map's getOrPut must run the factory exactly once per key, even under a
+            // concurrent storm — otherwise surplus delegates are registered but never tracked.
+            assertEquals(1, factoryCalls.get(), "factory ran ${factoryCalls.get()}× in round $round")
+            // Every add registers the single shared delegate.
+            assertTrue(registered.all { it === registered.first() }, "registered distinct delegates")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a thread-safety bug (P2). `ListenerIdentityMap` wrapped a plain `mutableMapOf` and documented
itself "not thread-safe — registration expected single-threaded per query." But
`DriverBackedSqkonQuery` owns **one map per query**, and `asFlow()` (callbackFlow) calls `add` on
collection start and `remove` in `awaitClose` on arbitrary dispatchers. A cold Flow collected by
multiple coroutines therefore mutates one map concurrently:

- concurrent `getOrPut` for the same key races → the factory runs more than once;
- the surplus delegate gets `register`ed with the driver but is **not** stored in the map, so it
  can never be `remove`d → a leaked driver-level listener.

## Fix

Guard the map mutation with a `Mutex` (`sqkonRunBlocking { mutex.withLock { … } }`, the same
pattern used by `SqkonConnectionPool` / `SqkonStatementCache`). The `register`/`unregister`
callback runs **outside** the lock — it calls into the driver and must not re-enter the lock.

## Test plan (TDD)

- Added `ListenerIdentityMapTest.concurrentAdd_sameKey_runsFactoryExactlyOnce` — a barrier-synced
  16-thread storm of `add()` for the same key (50 rounds). Written first, watched it fail on the
  unsynchronized map (factory ran more than once); passes with the Mutex (factory exactly once, one
  shared delegate registered).
- Full suite green: `./gradlew jvmTest` → **220 tests, 0 failures, 0 errors**.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
