### PR TITLE
fix: make schema migration stepwise/exhaustive + reject downgrades (#77)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/AndroidxSqkonDriver.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/androidx/AndroidxSqkonDriver.kt
@@ -36,7 +36,17 @@ internal class AndroidxSqkonDriver(
     private val listenersMutex = Mutex()
     private val listeners = linkedMapOf<String, MutableSet<SqkonDriver.Listener>>()
 
-    init { ensureSchema(schema) }
+    init {
+        // If schema init fails (e.g. a rejected downgrade or an unregistered migration step),
+        // close the pool so the lazily-opened writer connection isn't leaked — construction failed,
+        // so the caller never gets an instance to close(). See #77.
+        try {
+            ensureSchema(schema)
+        } catch (t: Throwable) {
+            pool.close()
+            throw t
+        }
+    }
 
     // ---------- SqkonDriver: execute ----------
 
@@ -135,6 +145,12 @@ internal class AndroidxSqkonDriver(
         try {
             val current = readUserVersion(connection)
             if (current == schema.version) return
+            // Reject downgrades loudly instead of silently rewriting user_version down — an older
+            // app must not "migrate" a database created by a newer schema. See #77.
+            check(current <= schema.version) {
+                "Database schema version ($current) is newer than this library's schema " +
+                    "(${schema.version}); downgrades are not supported."
+            }
             // Run schema work inside a transaction. Set thread-local so calls into this driver
             // (schema.create / schema.migrate -> driver.executeUpdate) reuse the writer connection
             // instead of re-acquiring (which would deadlock the mutex we already hold).

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonDatabaseSchema.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/internal/schema/SqkonDatabaseSchema.kt
@@ -13,17 +13,30 @@ internal object SqkonDatabaseSchema : SqkonSchema {
     }
 
     override fun migrate(driver: SqkonDriver, oldVersion: Long, newVersion: Long) {
-        if (oldVersion <= 1 && newVersion > 1) {
-            driver.exec(CREATE_METADATA_TABLE)
-            driver.exec("ALTER TABLE entity ADD COLUMN read_at INTEGER")
-            driver.exec("ALTER TABLE entity ADD COLUMN write_at INTEGER")
-            // write_at is read as epoch-millis (ResultRow uses Instant.fromEpochMilliseconds).
-            // 1.sqm used CURRENT_TIMESTAMP, which writes a text datetime that coerces to a bogus
-            // small integer (~the year) on an INTEGER column and breaks purge comparisons. Backfill
-            // real epoch-millis instead. strftime('%s') is whole seconds, so multiply to millis.
-            driver.exec("UPDATE entity SET write_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000")
-            CREATE_ENTITY_INDEXES.forEach(driver::exec)
+        // Apply each version step in turn. Any version with no registered migration fails loudly,
+        // so an unhandled delta can never silently bump user_version with no DDL applied (the caller
+        // writes user_version only after this returns). Downgrades are rejected by ensureSchema. #77
+        for (target in (oldVersion + 1)..newVersion) {
+            when (target) {
+                2L -> migrateToV2(driver)
+                else -> error(
+                    "No migration registered for schema version $target " +
+                        "(migrating $oldVersion -> $newVersion)"
+                )
+            }
         }
+    }
+
+    private fun migrateToV2(driver: SqkonDriver) {
+        driver.exec(CREATE_METADATA_TABLE)
+        driver.exec("ALTER TABLE entity ADD COLUMN read_at INTEGER")
+        driver.exec("ALTER TABLE entity ADD COLUMN write_at INTEGER")
+        // write_at is read as epoch-millis (ResultRow uses Instant.fromEpochMilliseconds).
+        // 1.sqm used CURRENT_TIMESTAMP, which writes a text datetime that coerces to a bogus
+        // small integer (~the year) on an INTEGER column and breaks purge comparisons. Backfill
+        // real epoch-millis instead. strftime('%s') is whole seconds, so multiply to millis.
+        driver.exec("UPDATE entity SET write_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000")
+        CREATE_ENTITY_INDEXES.forEach(driver::exec)
     }
 
     // All INTEGER timestamp columns hold UTC milliseconds. `value` holds JSONB; use jsonb_ operators.

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaMigrationGuardTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/SchemaMigrationGuardTest.kt
@@ -1,0 +1,62 @@
+package com.mercury.sqkon.db
+
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_CREATE
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_FULLMUTEX
+import androidx.sqlite.driver.bundled.SQLITE_OPEN_READWRITE
+import androidx.sqlite.execSQL
+import com.mercury.sqkon.db.internal.androidx.AndroidxSqkonDriver
+import com.mercury.sqkon.db.internal.androidx.SqkonConnectionFactory
+import com.mercury.sqkon.db.internal.schema.SqkonDatabaseSchema
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression tests for migration exhaustiveness / downgrade guard (#77). Previously `ensureSchema`
+ * routed any `current != version` to `migrate(...)` then unconditionally bumped `user_version` —
+ * so an unhandled delta (no DDL) or a downgrade silently corrupted the recorded version.
+ */
+class SchemaMigrationGuardTest {
+
+    private val flags = SQLITE_OPEN_READWRITE or SQLITE_OPEN_CREATE or SQLITE_OPEN_FULLMUTEX
+    private fun factory() = SqkonConnectionFactory { name -> BundledSQLiteDriver().open(name, flags) }
+
+    @Test
+    fun openingNewerSchemaVersion_failsLoudly_notSilentDowngrade() {
+        val dbFile = File.createTempFile("sqkon-downgrade-", ".db").apply { deleteOnExit() }
+        // Stamp the file with a future schema version.
+        BundledSQLiteDriver().open(dbFile.absolutePath, flags).use { it.execSQL("PRAGMA user_version = 99") }
+
+        // Opening with the current (older) schema must throw rather than rewrite user_version down.
+        assertFailsWith<IllegalStateException> {
+            AndroidxSqkonDriver(
+                factory = factory(),
+                name = dbFile.absolutePath,
+                isMemory = false,
+                schema = SqkonDatabaseSchema,
+                config = SqkonDriverConfig(readerConnections = 1),
+            )
+        }
+    }
+
+    @Test
+    fun migrate_toUnregisteredVersion_failsLoudly_notSilentBump() {
+        val driver = AndroidxSqkonDriver(
+            factory = factory(),
+            name = ":memory:",
+            isMemory = true,
+            schema = SqkonDatabaseSchema,
+            config = SqkonDriverConfig(),
+        )
+        try {
+            // No v2->v3 migration is registered: migrate must throw rather than no-op (a no-op would
+            // let ensureSchema bump user_version to 3 with no DDL applied).
+            assertFailsWith<IllegalStateException> {
+                SqkonDatabaseSchema.migrate(driver, oldVersion = 2, newVersion = 3)
+            }
+        } finally {
+            driver.close()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a forward-compat landmine (P2) in schema migration. `ensureSchema` routed any
`current != schema.version` to `migrate(current, target)` and then **unconditionally** wrote
`user_version = target`. But `migrate` only handled `oldVersion <= 1 && newVersion > 1`, so:

- a future delta with **no registered step** (e.g. v2→v3) ran no DDL yet still recorded the DB as
  the new version → silent corruption;
- a **downgrade** (older app opening a newer file) silently rewrote `user_version` down.

## Fix

- `migrate()` now iterates each version step and `error()`s on any version with no registered
  migration, so an unhandled delta can't silently bump `user_version` (the caller writes it only
  after `migrate` returns; on error the schema transaction rolls back, leaving `user_version`
  untouched).
- `ensureSchema` rejects downgrades (`current > schema.version`) with a clear error.

The v1→v2 migration is unchanged (extracted verbatim into `migrateToV2`).

## Test plan (TDD)

- Added `SchemaMigrationGuardTest`:
  - opening a DB stamped with a newer `user_version` throws `IllegalStateException`;
  - `migrate(oldVersion = 2, newVersion = 3)` throws (no v3 step registered).
  Both provably cannot pass on the old code (which never threw for these inputs).
- `SchemaMigrationTest` (v1→v2) and the `SchemaParityTest` gate still pass.
- Full suite green: `./gradlew jvmTest` → **222 tests, 0 failures, 0 errors**.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
