### PR TITLE
fix: expose public-API deps as api so consumers get them transitively (#78)

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -47,12 +47,16 @@ kotlin {
     iosSimulatorArm64()
     sourceSets {
         commonMain.dependencies {
+            // androidx.sqlite + collection are internal-only — keep them off the consumer classpath.
             implementation(libs.androidx.collection)
             implementation(libs.androidx.sqlite.core)
             implementation(libs.androidx.sqlite.bundled)
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.serialization.json)
-            implementation(libs.paging.common)
+            // These appear in Sqkon's public API and must be `api` so they land transitively on the
+            // consumer's compile classpath: coroutines (Flow<List<T>>, CoroutineScope), serialization
+            // (Json on Sqkon/SqkonSerializer), and paging (PagingSource from select*PagingSource). #78
+            api(libs.kotlinx.coroutines.core)
+            api(libs.kotlinx.serialization.json)
+            api(libs.paging.common)
             // Don't include other paging, just the base to generate pageable queries
         }
 


### PR DESCRIPTION
## Summary

Fixes a broken transitive classpath for consumers (P2). For a published library, any dependency
whose types appear in the **public API** must be `api` so it lands on the consumer's compile
classpath transitively. Three were declared `implementation`:

- **kotlinx-coroutines-core** — `Flow<List<T>>`, `CoroutineScope` on the `Sqkon(...)` factories
- **kotlinx-serialization-json** — `json: Json` on `Sqkon` / `KotlinSqkonSerializer` / `SqkonJson`
- **androidx.paging** (`paging-common`) — `PagingSource<…>` from `selectPagingSource` /
  `selectKeysetPagingSource`

Consumers compiled against the API but didn't transitively receive the types and had to re-declare
them.

## Fix

Promote those three to `api(...)` in `commonMain`. `androidx-sqlite-*` and `androidx-collection`
remain `implementation` — they're internal-only and intentionally kept off the consumer classpath.

## Test plan

Dependency-scope change only (no source change). The `api`→`apiElements` promotion is guaranteed by
Gradle semantics to place these on consumers' compile classpath. Build + full suite green:
`./gradlew jvmTest` → **222 tests, 0 failures, 0 errors**.

Follow-up worth considering (out of scope here): add the Kotlin binary-compatibility-validator with
committed `.api` dumps so the public surface — and its required `api` deps — is guarded in CI.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
