### PR TITLE
docs: fix non-compiling README/KDoc snippets + stale install version (#79)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,8 @@ SQLite and JSONB.
 ```kotlin
 // Create a new instance of Sqkon
 val sqkon = Sqkon(
-    context = context // (only for Android)
+    scope = appScope,   // a CoroutineScope you own (required on every platform)
+    context = context,  // Android only
 )
 
 // Create a Store for each type/entity you want to create
@@ -212,7 +213,7 @@ Multiplatform projects (Android, JVM; iOS on the roadmap):
 ```kotlin
 commonMain {
     dependencies {
-        implementation("com.mercury.sqkon:library:1.3.2")
+        implementation("com.mercury.sqkon:library:2.1.0") // x-release-please-version
     }
 }
 ```
@@ -222,7 +223,7 @@ right artifact for your target platform:
 
 ```kotlin
 dependencies {
-    implementation("com.mercury.sqkon:library:1.3.2")
+    implementation("com.mercury.sqkon:library:2.1.0") // x-release-please-version
 }
 ```
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/Sqkon.kt
@@ -11,12 +11,13 @@ import kotlinx.serialization.json.Json
  *
  * Each platform has a `Sqkon` function that creates a `Sqkon` instance.
  *
- * Simple usage:
+ * Simple usage (`scope` is a [kotlinx.coroutines.CoroutineScope] you own; on Android also pass
+ * `context`):
  * ```
- * val sqkon = Sqkon()
+ * val sqkon = Sqkon(scope = scope)
  * val merchantStore = sqkon.keyValueStorage<Merchant>("merchant")
  * merchantStore.insert(
- *  id = "123",
+ *  key = "123",
  *  value = Merchant(id = "123", name = "Chipotle", category = "Restaurant")
  * )
  * val merchant = merchantStore.selectByKey("123").first()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
+      "extra-files": ["README.MD"],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Fixes consumer-facing docs that didn't compile / were stale (P2).

1. **Stale install version** — README install snippets pinned `1.3.2` (the pre-migration
   SQLDelight era) while the latest release is **2.1.0**. Bumped both, annotated them with
   `// x-release-please-version`, and added `README.MD` to release-please `extra-files` so the
   version auto-bumps on future releases (no more drift).
2. **Quickstart didn't compile** — `Sqkon(context = context)` is missing the required
   `scope: CoroutineScope`. Added it (and clarified `context` is Android-only).
3. **`Sqkon.kt` KDoc didn't compile** — the entry-point example called `Sqkon()` (scope is
   required) and `insert(id = "123")` (the parameter is `key`). Fixed both.

## Test plan

Docs / KDoc-comment / release-please-config change only. `release-please-config.json` validated as
JSON; no `1.3.2` remains in the README; `./gradlew compileKotlinJvm` succeeds. Full CI runs as a
regression guard.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
