### PR TITLE
docs: keyset first-page cost is O(n) too, not O(pageSize) (#80 follow-up)

### DIFF
--- a/docs/guides/paging.md
+++ b/docs/guides/paging.md
@@ -20,7 +20,7 @@ hand it to a `Pager`.
 | | `selectPagingSource` (offset) | `selectKeysetPagingSource` (keyset) |
 |---|---|---|
 | **Key type** | `Int` (row offset) | `String` (entity key at page boundary) |
-| **First-page cost** | O(pageSize) | O(pageSize) for the load + O(n) once for boundary precompute |
+| **First-page cost** | O(pageSize) | O(n) for the load + O(n) once for boundary precompute |
 | **Late-page cost** | O(offset + pageSize) — grows with depth | O(n) ordered scan per page — depth-independent, boundary-stable under writes |
 | **Random page jumps** | yes | no (`jumpingSupported = false`) |
 | **Best for** | Small/medium datasets, random access | Large datasets, deep scrolling, `RemoteMediator` |


### PR DESCRIPTION
Follow-up to #80 addressing Copilot's review: the TL;DR table still listed keyset **first-page** load as `O(pageSize)`, contradicting the corrected Cost section. Each page load `ROW_NUMBER()`s the full filtered/ordered set — including page 1 — so the first-page cell is now `O(n)` for the load + `O(n)` once for boundary precompute.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)