### PR TITLE
fix: consistent paging load() error handling — return Error, rethrow Cancellation (#81)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -46,7 +46,7 @@ internal class KeysetQueryPagingSource<T : Any>(
     override suspend fun load(
         params: PagingSource.LoadParams<String>,
     ): PagingSource.LoadResult<String, T> = withContext(context) {
-        try {
+        loadResultCatching {
             val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult<String, T> =
                 {
                     // Always use the stable pageSize for boundary computation, not
@@ -107,9 +107,6 @@ internal class KeysetQueryPagingSource<T : Any>(
             val loadResult = transacter
                 .transactionWithResult(body = getPagingSourceLoadResult)
             if (invalid) PagingSource.LoadResult.Invalid() else loadResult
-        } catch (e: Exception) {
-            if (invalid) PagingSource.LoadResult.Invalid()
-            else PagingSource.LoadResult.Error(e)
         }
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -23,39 +23,41 @@ internal class OffsetQueryPagingSource<T : Any>(
     override suspend fun load(
         params: PagingSource.LoadParams<Int>,
     ): PagingSource.LoadResult<Int, T> = withContext(context) {
-        val key = params.key ?: initialOffset
-        val limit = when (params) {
-            is PagingSource.LoadParams.Prepend<*> -> minOf(key, params.loadSize)
-            else -> params.loadSize
-        }
-        val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult.Page<Int, T> =
-            {
-                val count = countQuery.executeAsOne()
-                val offset = when (params) {
-                    is PagingSource.LoadParams.Prepend<*> -> maxOf(0, key - params.loadSize)
-                    is PagingSource.LoadParams.Append<*> -> key
-                    is PagingSource.LoadParams.Refresh<*> -> {
-                        if (key >= count) maxOf(0, count - params.loadSize) else key
-                    }
-
-                    else -> error("Unknown PagingSourceLoadParams ${params::class}")
-                }
-                val data = queryProvider(limit, offset)
-                    .also { currentQuery = it }
-                    .executeAsList()
-                    .mapNotNull { deserialize(it) }
-                val nextPosToLoad = offset + data.size
-                PagingSource.LoadResult.Page(
-                    data = data,
-                    prevKey = offset.takeIf { it > 0 && data.isNotEmpty() },
-                    nextKey = nextPosToLoad.takeIf { data.isNotEmpty() && data.size >= limit && it < count },
-                    itemsBefore = offset,
-                    itemsAfter = maxOf(0, count - nextPosToLoad),
-                )
+        loadResultCatching {
+            val key = params.key ?: initialOffset
+            val limit = when (params) {
+                is PagingSource.LoadParams.Prepend<*> -> minOf(key, params.loadSize)
+                else -> params.loadSize
             }
-        val loadResult = transacter
-            .transactionWithResult(body = getPagingSourceLoadResult)
-        (if (invalid) PagingSource.LoadResult.Invalid() else loadResult)
+            val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult.Page<Int, T> =
+                {
+                    val count = countQuery.executeAsOne()
+                    val offset = when (params) {
+                        is PagingSource.LoadParams.Prepend<*> -> maxOf(0, key - params.loadSize)
+                        is PagingSource.LoadParams.Append<*> -> key
+                        is PagingSource.LoadParams.Refresh<*> -> {
+                            if (key >= count) maxOf(0, count - params.loadSize) else key
+                        }
+
+                        else -> error("Unknown PagingSourceLoadParams ${params::class}")
+                    }
+                    val data = queryProvider(limit, offset)
+                        .also { currentQuery = it }
+                        .executeAsList()
+                        .mapNotNull { deserialize(it) }
+                    val nextPosToLoad = offset + data.size
+                    PagingSource.LoadResult.Page(
+                        data = data,
+                        prevKey = offset.takeIf { it > 0 && data.isNotEmpty() },
+                        nextKey = nextPosToLoad.takeIf { data.isNotEmpty() && data.size >= limit && it < count },
+                        itemsBefore = offset,
+                        itemsAfter = maxOf(0, count - nextPosToLoad),
+                    )
+                }
+            val loadResult = transacter
+                .transactionWithResult(body = getPagingSourceLoadResult)
+            if (invalid) PagingSource.LoadResult.Invalid() else loadResult
+        }
     }
 
     override fun getRefreshKey(state: PagingState<Int, T>): Int? {

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/QueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/QueryPagingSource.kt
@@ -2,6 +2,7 @@ package com.mercury.sqkon.db.paging
 
 import androidx.paging.PagingSource
 import com.mercury.sqkon.db.internal.SqkonQuery
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.properties.Delegates
 
 internal abstract class QueryPagingSource<Key : Any, Value : Any> : PagingSource<Key, Value>(),
@@ -20,5 +21,21 @@ internal abstract class QueryPagingSource<Key : Any, Value : Any> : PagingSource
     }
 
     final override fun queryResultsChanged() = invalidate()
+
+    /**
+     * Runs a `load` body, turning a failure into a `LoadResult` instead of throwing out of
+     * `load()` (which can crash the collecting coroutine). [CancellationException] is rethrown so
+     * structured concurrency is preserved — it must never be reported as a load error. If the
+     * source was invalidated mid-load the result is [PagingSource.LoadResult.Invalid]. See #81.
+     */
+    protected inline fun loadResultCatching(
+        block: () -> PagingSource.LoadResult<Key, Value>,
+    ): PagingSource.LoadResult<Key, Value> = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        if (invalid) PagingSource.LoadResult.Invalid() else PagingSource.LoadResult.Error(e)
+    }
 
 }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingErrorHandlingTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingErrorHandlingTest.kt
@@ -1,0 +1,87 @@
+package com.mercury.sqkon.db
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource.LoadResult
+import androidx.paging.testing.TestPager
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.db.paging.KeysetQueryPagingSource
+import com.mercury.sqkon.db.paging.OffsetQueryPagingSource
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertTrue
+
+/**
+ * Error-handling contract for the paging sources (#81):
+ *  - a query/deserialization failure must surface as `LoadResult.Error`, not propagate out of
+ *    `load()` (which can crash the collecting coroutine) — the offset source had no try/catch;
+ *  - `CancellationException` must be rethrown, never converted into `LoadResult.Error` — the keyset
+ *    source caught it via a blanket `catch (Exception)`.
+ */
+class PagingErrorHandlingTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope,
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun offsetPagingSource_deserializeFailure_returnsLoadResultError_doesNotThrow() = runTest {
+        storage.insertAll((1..5).map { TestObject() }.associateBy { it.id })
+
+        val source = OffsetQueryPagingSource<TestObject>(
+            queryProvider = { limit, offset ->
+                entityQueries.select("test-object", limit = limit.toLong(), offset = offset.toLong())
+            },
+            countQuery = entityQueries.count("test-object"),
+            transacter = entityQueries,
+            context = Dispatchers.IO,
+            deserialize = { throw RuntimeException("boom") },
+            initialOffset = 0,
+        )
+
+        // Before the fix this throws out of load(); now it must come back as Error.
+        val result = TestPager(PagingConfig(pageSize = 10), source).refresh()
+        assertTrue(result is LoadResult.Error, "expected LoadResult.Error, got $result")
+    }
+
+    @Test
+    fun keysetPagingSource_cancellation_isRethrown_notReportedAsError() = runTest {
+        storage.insertAll((1..5).map { TestObject() }.associateBy { it.id })
+
+        val source = KeysetQueryPagingSource<TestObject>(
+            queryProvider = entityQueries.selectKeyed("test-object"),
+            pageBoundariesProvider = entityQueries.selectPageBoundaries("test-object"),
+            boundaryForKeyProvider = entityQueries.selectBoundaryForKey("test-object"),
+            transacter = entityQueries,
+            context = Dispatchers.IO,
+            deserialize = { throw CancellationException("cancelled") },
+            pageSize = 10,
+        )
+
+        // CancellationException must propagate (structured concurrency), not be swallowed into Error.
+        val pager = TestPager(PagingConfig(pageSize = 10), source)
+        val thrown: Throwable? = try {
+            pager.refresh()
+            null
+        } catch (e: Throwable) {
+            e
+        }
+        assertTrue(
+            thrown is CancellationException,
+            "expected CancellationException to propagate, got $thrown",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes inconsistent paging `load()` error handling (P2).

- **`OffsetQueryPagingSource.load()`** had no try/catch — a SQL or deserialization error propagated
  straight out of `load()`, which can crash the collecting coroutine (inconsistent with the keyset
  source, which wrapped its body).
- **`KeysetQueryPagingSource.load()`** used a blanket `catch (e: Exception)` that also caught
  `CancellationException` and returned `LoadResult.Error` — swallowing cancellation and breaking
  structured concurrency.

## Fix

Factor the shared contract into `QueryPagingSource.loadResultCatching`:

- **rethrow `CancellationException`** (never report cancellation as a load error);
- return `LoadResult.Invalid` if the source was invalidated mid-load;
- otherwise return `LoadResult.Error`.

Both sources route their `load` body through it, so the offset source now returns `Error` instead
of throwing, and the keyset source no longer swallows cancellation.

## Test plan (TDD)

- Added `PagingErrorHandlingTest`:
  - offset: a deserialize failure surfaces as `LoadResult.Error` (previously thrown out of `load()`);
  - keyset: a `CancellationException` propagates (previously converted to `LoadResult.Error`).
- Existing offset + keyset paging tests still pass (happy path unchanged).
- Full suite green: `./gradlew jvmTest` → **224 tests, 0 failures, 0 errors**.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
