### PR TITLE
fix: alias SqlException to androidx.sqlite.SQLiteException so catches fire (#82)

### DIFF
--- a/library/src/androidMain/kotlin/com/mercury/sqkon/db/EntityQueries.android.kt
+++ b/library/src/androidMain/kotlin/com/mercury/sqkon/db/EntityQueries.android.kt
@@ -1,3 +1,0 @@
-package com.mercury.sqkon.db
-
-actual typealias SqlException = java.sql.SQLException

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/EntityQueries.kt
@@ -1,5 +1,6 @@
 package com.mercury.sqkon.db
 
+import androidx.sqlite.SQLiteException
 import com.mercury.sqkon.db.internal.ListenerIdentityMap
 import com.mercury.sqkon.db.internal.SqkonCursor
 import com.mercury.sqkon.db.internal.SqkonDriver
@@ -568,4 +569,7 @@ internal const val ALL_ENTITIES_KEY = "entity"
 internal fun entityKey(entityName: String): String = "entity_$entityName"
 
 
-expect class SqlException : Exception
+// Alias to the exception the bundled androidx.sqlite driver actually throws. Previously this was
+// `expect class SqlException` aliased per-platform to java.sql.SQLException (JVM/Android) — a type
+// the driver never throws — so every `catch (ex: SqlException)` breadcrumb block was dead code. #82
+internal typealias SqlException = SQLiteException

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEdgeCasesTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageEdgeCasesTest.kt
@@ -9,8 +9,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
-import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class KeyValueStorageEdgeCasesTest {
 
@@ -38,14 +37,12 @@ class KeyValueStorageEdgeCasesTest {
         val first = TestObject(id = "k", name = "first")
         val second = TestObject(id = "k", name = "second")
         store.insert("k", first)
-        val ex = assertFails {
+        // The duplicate PRIMARY KEY now surfaces as `SqlException` — the real driver exception type
+        // (androidx.sqlite.SQLiteException) the breadcrumb catch blocks rely on. Before #82,
+        // SqlException aliased java.sql.SQLException, so this would not have matched.
+        assertFailsWith<SqlException> {
             store.insert("k", second, ignoreIfExists = false)
         }
-        assertTrue(
-            ex::class.java.name.contains("SQLite") || ex.message?.contains("UNIQUE") == true
-                    || ex.message?.contains("PRIMARY KEY") == true,
-            "unexpected exception type ${ex::class}: $ex",
-        )
     }
 
     @Test

--- a/library/src/iosMain/kotlin/com/mercury/sqkon/db/SqlException.ios.kt
+++ b/library/src/iosMain/kotlin/com/mercury/sqkon/db/SqlException.ios.kt
@@ -1,4 +1,0 @@
-package com.mercury.sqkon.db
-
-actual class SqlException(message: String? = null, cause: Throwable? = null) :
-    Exception(message, cause)

--- a/library/src/jvmMain/kotlin/com/mercury/sqkon/db/EntityQueries.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/mercury/sqkon/db/EntityQueries.jvm.kt
@@ -1,3 +1,0 @@
-package com.mercury.sqkon.db
-
-actual typealias SqlException = java.sql.SQLException


### PR DESCRIPTION
## Summary

Fixes dead error-handling code (P2). `SqlException` was an `expect`/`actual` aliased to
`java.sql.SQLException` on JVM/Android (and a hand-rolled class on iOS). But the bundled
`androidx.sqlite` driver throws **`androidx.sqlite.SQLiteException`** (a `RuntimeException`
unrelated to `java.sql.SQLException`), and `AndroidxSqkonDriver` does no exception translation. So
all six `catch (ex: SqlException)` breadcrumb blocks in `EntityQueries` and
`MetadataQueries.withSqlBreadcrumb` were **dead code** — they never caught a real driver error.

## Fix (the ticket's option a)

Replace the `expect`/`actual` with a single commonMain
`internal typealias SqlException = androidx.sqlite.SQLiteException` (it's commonMain-available,
including Kotlin/Native — verified iOS compiles), and delete the two JVM/Android actuals + the iOS
hand-rolled class. The breadcrumb catches now match the type the driver actually throws.

`SqlException` is used only by those internal catches (no public signature), so it's `internal` and
`androidx.sqlite` stays an `implementation` dependency (consistent with #78).

## Test plan (TDD)

- Strengthened `KeyValueStorageEdgeCasesTest.insert_ignoreIfExistsFalse_throwsOnDuplicate` from a
  `class.name.contains("SQLite")` string-match to `assertFailsWith<SqlException>` — which only
  passes because `SqlException` now matches the real driver exception (it would have failed under
  the old `java.sql.SQLException` alias).
- `./gradlew jvmTest` → **224 tests, 0 failures, 0 errors**; `compileKotlinIosSimulatorArm64`
  succeeds.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
