### PR TITLE
test: cover oversized IN-list + SQL-error breadcrumb-rethrow paths (#84)

### DIFF
--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/SqlErrorAndInListTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/SqlErrorAndInListTest.kt
@@ -1,0 +1,66 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Coverage for the IN-list bound-variable limit and the SQL-error breadcrumb path (#84).
+ *
+ * `selectByKeys` / `deleteByKeys` / `updateReadForEntities` build `IN (?, ?, …)` dynamically, so
+ * the key-set size becomes the SQLite bound-variable count (limit `SQLITE_MAX_VARIABLE_NUMBER`,
+ * 32766 on modern SQLite). These tests assert a large-but-valid set works, and an over-limit set
+ * fails loudly with the original `SqlException` (the EntityQueries breadcrumb rethrows it, never
+ * swallows it).
+ */
+class SqlErrorAndInListTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val store = keyValueStorage<TestObject>("inlist", entityQueries, metadataQueries, mainScope)
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    @Test
+    fun selectByKeys_largeKeySet_returnsAllRows() = runTest {
+        // 2000 keys: well under the 32766 bound-variable limit. The read also drives
+        // updateReadForEntities over the same 2000 keys (another IN(?,…) site).
+        val objects = (1..2000).map { TestObject() }.associateBy { it.id }
+        store.insertAll(objects)
+
+        val result = store.selectByKeys(objects.keys.toList()).first()
+        assertEquals(objects.size, result.size)
+    }
+
+    @Test
+    fun deleteByKeys_largeKeySet_deletesAll() = runTest {
+        val objects = (1..2000).map { TestObject() }.associateBy { it.id }
+        store.insertAll(objects)
+
+        store.deleteByKeys(*objects.keys.toTypedArray())
+
+        assertEquals(0, store.selectAll().first().size)
+    }
+
+    @Test
+    fun selectByKeys_overVariableLimit_failsWithSqlException_notSilently() = runTest {
+        // 40000 > SQLITE_MAX_VARIABLE_NUMBER (32766): the IN(?,…) list exceeds the bound-variable
+        // limit. The driver must raise a SqlException, and the EntityQueries select breadcrumb must
+        // rethrow it with the original type — not swallow it or return a silently wrong result.
+        val tooManyKeys = (1..40_000).map { "k$it" }
+        assertFailsWith<SqlException> {
+            store.selectByKeys(tooManyKeys).first()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the error-surface coverage flagged in #84. `selectByKeys` / `deleteByKeys` /
`updateReadForEntities` build `IN (?, ?, …)` dynamically, so the key-set size is the SQLite
bound-variable count — and the SQL-error breadcrumb path had no test. New `SqlErrorAndInListTest`:

- **`selectByKeys_largeKeySet_returnsAllRows`** + **`deleteByKeys_largeKeySet_deletesAll`** — 2000
  keys (well under `SQLITE_MAX_VARIABLE_NUMBER` = 32766) return correct results; the read path also
  drives `updateReadForEntities` over the same 2000 keys.
- **`selectByKeys_overVariableLimit_failsWithSqlException_notSilently`** — 40000 keys (> 32766) fail
  with `SqlException`. This proves the over-limit case is a **loud, original-typed failure** that the
  `EntityQueries` breadcrumb rethrows rather than swallowing or returning a silently-wrong result —
  and is end-to-end validation of the #82 `SqlException` typealias.

Decision on chunking: not needed below 32766; the over-limit case fails clearly (documented by the
test) rather than silently, which is the desired behavior for a deliberately pathological key set.

## Test plan

Tests only. Full suite green: `./gradlew jvmTest` → **230 tests, 0 failures, 0 errors**.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
