### PR TITLE
chore: remove dead code & deprecate misnamed deleteState (#85)

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -52,7 +52,6 @@ class JsonPathBuilder<R : Any>
         block: JsonPathNode<R, V>.() -> Unit = {}
     ): JsonPathBuilder<R> {
         parentNode = JsonPathNode<R, V>(
-            //parent = null,
             propertyName = serialName ?: property.name,
             receiverDescriptor = serializer<R1>().descriptor,
             valueDescriptor = serializer<V>().descriptor
@@ -68,7 +67,6 @@ class JsonPathBuilder<R : Any>
         block: JsonPathNode<R, V>.() -> Unit = {}
     ): JsonPathBuilder<R> {
         parentNode = JsonPathNode<R, V>(
-            //parent = null,
             propertyName = serialName ?: property.name,
             receiverBaseDescriptor = if (baseType != typeOf<R1>()) {
                 serializer(baseType).descriptor
@@ -88,7 +86,6 @@ class JsonPathBuilder<R : Any>
         block: JsonPathNode<R, V>.() -> Unit = {}
     ): JsonPathBuilder<R> {
         parentNode = JsonPathNode<R, V>(
-            //parent = null,
             propertyName = serialName ?: property.name,
             receiverDescriptor = serializer<R1>().descriptor,
             valueDescriptor = serializer<Collection<V>>().descriptor
@@ -249,7 +246,6 @@ inline fun <reified R : Any, reified V : Any?> KClass<R>.withList(
 class JsonPathNode<R : Any?, V : Any?>
 @PublishedApi
 internal constructor(
-    //@PublishedApi internal val parent: JsonPathNode<*, R>?,
     val propertyName: String,
     internal val receiverBaseDescriptor: SerialDescriptor? = null,
     internal val receiverDescriptor: SerialDescriptor,
@@ -269,7 +265,6 @@ internal constructor(
         block: JsonPathNode<V1, V2>.() -> Unit = {}
     ): JsonPathNode<R, V> {
         child = JsonPathNode<V1, V2>(
-            //parent = this,
             propertyName = serialName ?: property.name,
             receiverDescriptor = serializer<V1>().descriptor,
             valueDescriptor = serializer<V2>().descriptor
@@ -289,7 +284,6 @@ internal constructor(
         block: JsonPathNode<out V, V2>.() -> Unit = {}
     ): JsonPathNode<R, out V> {
         child = JsonPathNode<V, V2>(
-            //parent = this,
             propertyName = serialName ?: property.name,
             receiverDescriptor = valueDescriptor,
             valueDescriptor = serializer<Collection<V2>>().descriptor
@@ -301,29 +295,3 @@ internal constructor(
         return "JsonPathNode(propertyName='$propertyName', receiverDescriptor=$receiverDescriptor, valueDescriptor=$valueDescriptor)"
     }
 }
-
-//private fun testBlock() {
-//    val pathBuilder: JsonPathBuilder<Test> = Test::class.with(Test::child) {
-//        then(TestChild::child2) {
-//            then(TestChild2::childValue2)
-//        }
-//    }
-//    val pathBuilderWithList = Test::class.withList(Test::childList) {
-//        then(TestChild::childValue)
-//    }
-//}
-
-//private data class Test(
-//    val value: String,
-//    val child: TestChild,
-//    val childList: List<TestChild>,
-//)
-//
-//private data class TestChild(
-//    val childValue: String,
-//    val child2: TestChild2,
-//)
-//
-//private data class TestChild2(
-//    val childValue2: String,
-//)

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -516,6 +516,10 @@ open class KeyValueStorage<T : Any>(
      *
      * @see deleteExpired
      */
+    @Deprecated(
+        "Misnamed twin of deleteStale; this just forwards to deleteStale(instant, instant).",
+        ReplaceWith("deleteStale(writeInstant = instant, readInstant = instant)"),
+    )
     fun deleteState(instant: Instant) {
         deleteStale(instant, instant)
     }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/RequestHash.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/utils/RequestHash.kt
@@ -1,8 +1,0 @@
-package com.mercury.sqkon.db.utils
-
-import kotlin.coroutines.AbstractCoroutineContextElement
-import kotlin.coroutines.CoroutineContext
-
-internal class RequestHash(val hash: Int) : AbstractCoroutineContextElement(Key) {
-    companion object Key : CoroutineContext.Key<RequestHash>
-}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageStaleTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeyValueStorageStaleTest.kt
@@ -47,6 +47,17 @@ class KeyValueStorageStaleTest {
         }
     }
 
+    @Suppress("DEPRECATION")
+    @Test
+    fun deleteState_delegatesToDeleteStale() = runTest {
+        val expected = (0..4).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+        // deleteState forwards to deleteStale(instant, instant); a far-future cutoff makes every
+        // (write-stale) row qualify, so all rows are purged.
+        testObjectStorage.deleteState(Clock.System.now().plus(1.days))
+        assertEquals(0, testObjectStorage.selectAll().first().size)
+    }
+
     @Test
     fun insertAll_staleInPast() = runTest {
         val now = Clock.System.now()


### PR DESCRIPTION
## Summary

Dead-code / hygiene cleanup (P3, batch #85). Safe deletions + one deprecation:

- **Delete `RequestHash.kt`** — unreferenced dead code.
- **Delete JsonPath scratch** — the commented-out `testBlock` + `Test`/`TestChild`/`TestChild2`
  data classes at the end of `JsonPath.kt`, and the stale `//parent = …` / `//@PublishedApi … parent`
  fragments scattered through it.
- **Deprecate `KeyValueStorage.deleteState`** — an undocumented, callerless misnamed twin that just
  forwards to `deleteStale(instant, instant)`. `@Deprecated(ReplaceWith("deleteStale(instant, instant)"))`
  (non-breaking) + a delegation test.

## Already done / deferred (from this batch)

- The commented-out enum `@SerialName` block in `bindValue` was already removed in #73.
- The stdout `println` SQL-error breadcrumbs (×7) overlap with #87's "consolidate
  `withSqlBreadcrumb`" item — addressed there (same code).
- The `slowWrite` test seam is **kept**: `ConcurrencyTest` and `KeyValueStorageTest` actively drive
  it, and relocating it out of `insertEntity`/`updateEntity` needs a test rework (it's `internal`,
  not public API). Noted for a future dedicated change.

## Test plan

`./gradlew jvmTest` → **231 tests, 0 failures, 0 errors** (added `deleteState_delegatesToDeleteStale`).

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
