### PR TITLE
chore: sync docs & build metadata (#86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-      - name: Build and publish
+      - name: Import guard + JVM tests
         run: ./gradlew checkNoSqlDelightImports jvmTest
 
       - name: JUnit Report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Run `./gradlew jvmTest` for the primary development loop. Always run this before
 Single `:library` module with KMP source sets (`commonMain`, `androidMain`, `jvmMain` + test counterparts).
 
 **Core classes** (package `com.mercury.sqkon.db`):
-- `Sqkon` — entry point; use `sqkon.keyValueStore<T>(name)` to create stores
+- `Sqkon` — entry point; use `sqkon.keyValueStorage<T>(name)` to create stores
 - `KeyValueStorage<T>` — CRUD, querying, paging, expiry; all queries return `Flow<T>`
 - `EntityQueries` / `MetadataQueries` — hand-rolled query layer over the internal `SqkonDriver`
 - `JsonPath` — type-safe WHERE DSL (`MyType::field eq "value"`)
@@ -72,6 +72,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/). Release-please
 **CI** (`.github/workflows/ci.yml`) runs on every push/PR to `main`:
 1. `jvm-tests` — `jvmTest` (which runs `SchemaParityTest` + `SchemaMigrationTest` as the schema gate)
 2. `run-android-tests` — `allDevicesDebugAndroidTest` on managed emulator
+3. `Compile iOS targets` — compiles the iOS Kotlin/Native targets (the iOS scaffold must keep building)
 
 **Releases** are automated via [release-please](https://github.com/googleapis/release-please):
 1. Merge PRs to `main` with conventional commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,9 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on every push and PR to `main`:
 
 - **`jvm-tests`** — runs `./gradlew jvmTest`. `SchemaParityTest` + `SchemaMigrationTest` are the schema regression gate.
 - **`run-android-tests`** — runs `./gradlew allDevicesDebugAndroidTest` on a managed emulator.
+- **`Compile iOS targets`** — compiles the iOS Kotlin/Native targets so the iOS scaffold keeps building.
 
-Both jobs must pass before a PR can merge. JUnit reports are surfaced as GitHub check annotations.
+All three jobs must pass before a PR can merge. JUnit reports are surfaced as GitHub check annotations.
 
 ## Releases
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 # Maven
 GROUP=com.mercury.sqkon
-VERSION_NAME=1.2.0
+VERSION_NAME=2.1.0
 POM_NAME=Sqkon
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/MercuryTechnologies/sqkon/

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/JsonPath.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
 /**
- * Create a Path builder using one of the manu reified methods.
+ * Create a Path builder using one of the many reified methods.
  *
  * From a class:
  *
@@ -98,7 +98,7 @@ class JsonPathBuilder<R : Any>
         val nodes = mutableListOf<JsonPathNode<*, *>>()
         var node: JsonPathNode<*, *>? = parentNode
         while (node != null) {
-            // Insert additional node for parent classes incase they are sealed classes
+            // Insert additional node for parent classes in case they are sealed classes
             if (node.receiverBaseDescriptor != null) {
                 nodes.add(
                     JsonPathNode<Any, Any>(

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -131,7 +131,7 @@ open class KeyValueStorage<T : Any>(
     }
 
     /**
-     * Convenience function to insert collection of rows. If the row does not exist, ti will update
+     * Convenience function to insert collection of rows. If the row does not exist, it will update
      * nothing, use [insert] if you want to insert if the row does not exist.
      *
      * @param expiresAt if set, will be used to expire the row when requesting data before it has
@@ -275,7 +275,7 @@ open class KeyValueStorage<T : Any>(
      * )
      * ```
      *
-     * The result row is useful if you need metadata on the row level specific to Sqkon intead of
+     * The result row is useful if you need metadata on the row level specific to Sqkon instead of
      * your entity.
      */
     fun selectResult(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,12 +22,6 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
-        maven {
-            setUrl("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github.*")
-            }
-        }
         google {
             content {
                 includeGroupByRegex("com\\.android.*")


### PR DESCRIPTION
## Summary

Docs & build-metadata drift cleanup (P3, batch #86):

- **`CLAUDE.md`** — `keyValueStore<T>` → `keyValueStorage<T>` (real method name); add the
  `Compile iOS targets` CI job to the CI section.
- **`CONTRIBUTING.md`** — add the `Compile iOS targets` CI job.
- **`gradle.properties`** — bump `VERSION_NAME` `1.2.0` → `2.1.0`; the stale value poisoned local
  `publishToMavenLocal` / the `version` task.
- **Public KDoc typos** — "ti will" → "it will", "intead" → "instead", "manu" → "many",
  "incase" → "in case" (`KeyValueStorage.kt`, `JsonPath.kt`).
- **`settings.gradle.kts`** — remove the unused jitpack repository (no `com.github` dependencies).
- **`ci.yml`** — rename the mislabeled "Build and publish" step to "Import guard + JVM tests"
  (it runs `checkNoSqlDelightImports` + `jvmTest`; it never publishes).

Note: the orphaned `sample` module is already excluded from the build (`//":sample"` in
`settings.gradle.kts`); left as-is rather than deleted.

## Test plan

Docs/metadata only. `./gradlew jvmTest` builds and passes (dependency resolution unaffected by the
jitpack removal). CI runs as a regression guard.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
