### PR TITLE
chore: represent the iOS scaffold honestly (#89)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -218,6 +218,10 @@ commonMain {
 }
 ```
 
+> **iOS status:** the iOS targets currently publish a **compile-only scaffold** — there is no
+> `Sqkon()` entry point on iOS yet, and the internal driver is unimplemented (constructing one
+> throws). Use Sqkon on **Android and JVM** today; iOS runtime support is on the roadmap.
+
 Android-only or JVM-only projects use the same coordinate — Gradle resolves the
 right artifact for your target platform:
 

--- a/library/src/iosMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.ios.kt
+++ b/library/src/iosMain/kotlin/com/mercury/sqkon/db/SqkonDatabaseDriver.ios.kt
@@ -15,5 +15,11 @@ internal actual val defaultSqkonDispatchers: SqkonDispatchers by lazy {
 
 internal actual class DriverFactory {
     actual fun createDriver(): SqkonDriver =
-        TODO("iOS driver not yet implemented (BundledSQLiteDriver available; wiring is post-Phase-6)")
+        // The iOS target is a compile-only scaffold: it publishes a klib but has no working driver
+        // (and no public Sqkon() entry point) yet. Fail fast and explicitly rather than appear
+        // usable. iOS runtime support is on the roadmap — see the README "iOS status" note.
+        throw NotImplementedError(
+            "Sqkon does not support iOS at runtime yet — the iOS target is a compile-only scaffold. " +
+                "Use the Android or JVM targets; iOS support is on the roadmap.",
+        )
 }


### PR DESCRIPTION
## Summary

iOS scaffold honesty (P3, batch #89). The iOS targets publish a **compile-only klib** but have no
public `Sqkon()` entry point and an unimplemented driver, so iOS isn't usable at runtime. Make that
explicit rather than letting the published klib look functional:

- **README** — add an "iOS status" note: compile-only scaffold, no `Sqkon()` entry point yet, use
  Android/JVM today, iOS support on the roadmap.
- **`SqkonDatabaseDriver.ios.kt`** — replace the terse `TODO(...)` with an explicit
  `NotImplementedError` whose message says iOS isn't runtime-supported yet (fails fast and
  self-documents instead of `An operation is not implemented: …`).

## Deferred (noted on the issue)

Refinements to incomplete iOS internals / a deliberate redesign, best done when iOS is actually
wired:

- per-instance iOS `TransactionsThreadLocal` (vs the current process-global `@ThreadLocal`);
- cross-platform write-dispatcher strategy alignment;
- wiring `SqkonDriverConfig.readerConnections` into the read-dispatcher parallelism (currently
  hardcoded to `connectionPoolSize` on JVM/Android — a real but separate dispatcher-config coupling
  worth its own change).

## Test plan

`compileKotlinIosSimulatorArm64` succeeds (the `throw` is a `Nothing` expression); `./gradlew
jvmTest` passes. Docs + an iOS-only error-message change — no shipping-platform behavior change.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
