### PR TITLE
fix: report keyset paging item counts for stable scroll position

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -397,6 +397,7 @@ open class KeyValueStorage<T : Any>(
             },
             pageBoundariesProvider = pageBoundariesProvider,
             boundaryForKeyProvider = boundaryForKeyProvider,
+            countQuery = entityQueries.count(entityName, where = where, expiresAfter = expiresAfter),
             transacter = entityQueries,
             context = readDispatcher,
             deserialize = { it.deserialize() },

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -26,6 +26,12 @@ import kotlin.coroutines.CoroutineContext
  *   for the page that contains it. Used to snap a refresh key that came from stale boundaries
  *   (e.g. a RemoteMediator wrote rows between the previous source's load and the new source's
  *   boundary recomputation) back onto a real boundary in the new set.
+ * @param countQuery Total (DISTINCT-entity) row count. Reported as [PagingSource.LoadResult.Page]
+ *   itemsBefore/itemsAfter so Paging3 keeps ABSOLUTE list indices — a mediator-write invalidation
+ *   then preserves scroll position instead of collapsing the loaded window. Executed at most once
+ *   per source, and only when the consumer enables placeholders (skipped otherwise — Paging then
+ *   uses COUNT_UNDEFINED with no count query). Positions are exact when each entity maps to one row
+ *   (the common case); a json_tree-multiplying `where` inherits keyset's raw-row over-count (#68).
  * @param transacter Used to run queries within a transaction for consistency.
  * @param context Coroutine context for query execution.
  * @param deserialize Converts an [Entity] to the target type, returning null to skip.
@@ -34,6 +40,7 @@ internal class KeysetQueryPagingSource<T : Any>(
     private val queryProvider: (beginInclusive: String, endExclusive: String?) -> SqkonQuery<Entity>,
     private val pageBoundariesProvider: (anchor: String?, limit: Long) -> SqkonQuery<String>,
     private val boundaryForKeyProvider: (lookupKey: String, limit: Long) -> SqkonQuery<String>,
+    private val countQuery: SqkonQuery<Int>,
     private val transacter: SqkonTransacter,
     private val context: CoroutineContext,
     private val deserialize: (Entity) -> T?,
@@ -41,6 +48,7 @@ internal class KeysetQueryPagingSource<T : Any>(
 ) : QueryPagingSource<String, T>() {
 
     private var pageBoundaries: List<String>? = null
+    private var totalCount: Int = 0
 
     override val jumpingSupported: Boolean get() = false
 
@@ -56,6 +64,10 @@ internal class KeysetQueryPagingSource<T : Any>(
                         val boundariesQuery = pageBoundariesProvider(params.key, pageSize.toLong())
                         val list = boundariesQuery.executeAsList()
                         pageBoundaries = list
+                        // Only when the consumer uses placeholders: otherwise Paging ignores
+                        // itemsBefore/itemsAfter, so skip the COUNT query entirely. Once per source,
+                        // in the boundaries' transaction (keeps count and boundaries consistent).
+                        if (params.placeholdersEnabled) totalCount = countQuery.executeAsOne()
                         if (list.isEmpty()) {
                             // Register a listener on the boundaries query so an empty→populated
                             // transition (e.g., RemoteMediator initial write) triggers invalidation.
@@ -69,6 +81,8 @@ internal class KeysetQueryPagingSource<T : Any>(
                             data = emptyList(),
                             prevKey = null,
                             nextKey = null,
+                            itemsBefore = 0,
+                            itemsAfter = 0,
                         )
                     } else {
                         // Snap params.key to a boundary in the freshly computed set. The key may
@@ -98,11 +112,25 @@ internal class KeysetQueryPagingSource<T : Any>(
                             .executeAsList()
                             .mapNotNull { deserialize(it) }
 
-                        PagingSource.LoadResult.Page(
-                            data = results,
-                            prevKey = previousKey,
-                            nextKey = nextKey,
-                        )
+                        if (params.placeholdersEnabled) {
+                            // Boundaries sit every pageSize rows, so page keyIndex starts at row
+                            // keyIndex * pageSize; coerce guards boundary/count skew.
+                            val itemsBefore = (keyIndex * pageSize).coerceAtMost(totalCount)
+                            PagingSource.LoadResult.Page(
+                                data = results,
+                                prevKey = previousKey,
+                                nextKey = nextKey,
+                                itemsBefore = itemsBefore,
+                                itemsAfter = (totalCount - itemsBefore - results.size).coerceAtLeast(0),
+                            )
+                        } else {
+                            // Placeholders off → Paging uses COUNT_UNDEFINED; no count needed.
+                            PagingSource.LoadResult.Page(
+                                data = results,
+                                prevKey = previousKey,
+                                nextKey = nextKey,
+                            )
+                        }
                     }
                 }
             val loadResult = transacter

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
@@ -1,0 +1,122 @@
+package com.mercury.sqkon.db
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource.LoadResult
+import androidx.paging.testing.TestPager
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.db.internal.SqkonCursor
+import com.mercury.sqkon.db.internal.SqkonDriver
+import com.mercury.sqkon.db.internal.SqkonStatement
+import com.mercury.sqkon.db.internal.SqkonTransaction
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Performance regression guards for keyset paging: the per-source queries (total count and page
+ * boundaries) must be computed ONCE per PagingSource, not re-run on every page load. Uses a
+ * [CountingDriver] to count actual SQL executions — deterministic, no timing.
+ */
+class KeysetPagingPerformanceTest {
+
+    private val mainScope = MainScope()
+    private val driver = CountingDriver(driverFactory().createDriver())
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() = mainScope.cancel()
+
+    @Test
+    fun countQuery_runsOncePerSource_notPerPageLoad() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10, enablePlaceholders = true)
+        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = 10))
+
+        driver.queries.clear() // ignore insert/setup SQL
+        with(pager) { refresh(); append(); append() } // 3 page loads on ONE source
+
+        assertEquals(
+            1, driver.countMatching("COUNT(DISTINCT"),
+            "total-count query must run once per source, not once per page load",
+        )
+    }
+
+    @Test
+    fun countQuery_skipped_whenPlaceholdersDisabled() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        // enablePlaceholders=false requires prefetchDistance>0 (PagingConfig invariant).
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 1, initialLoadSize = 10, enablePlaceholders = false)
+        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = 10))
+
+        driver.queries.clear()
+        with(pager) { refresh(); append(); append() }
+
+        assertEquals(
+            0, driver.countMatching("COUNT(DISTINCT"),
+            "with placeholders disabled Paging ignores item counts — the COUNT query must not run",
+        )
+    }
+
+    @Test
+    fun pageBoundaries_computedOncePerSource_notPerPageLoad() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = 10))
+
+        driver.queries.clear()
+        val last = with(pager) { refresh(); append(); append() } as LoadResult.Page
+
+        assertEquals(3, pager.getPages().size, "fixture: three pages loaded on one source")
+        // selectPageBoundaries is the only paged query using a modulo predicate ("(rn - 1) % ?").
+        assertEquals(
+            1, driver.countMatching("% ?"),
+            "page-boundaries query must be computed once per source, not once per page load",
+        )
+        assertEquals(10, last.data.size, "fixture: full final page")
+    }
+}
+
+/** Delegating [SqkonDriver] that records the SQL of every executeQuery for assertions. */
+private class CountingDriver(private val delegate: SqkonDriver) : SqkonDriver {
+    val queries = mutableListOf<String>()
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqkonStatement.() -> Unit)?,
+        mapper: (SqkonCursor) -> R,
+    ): R {
+        queries += sql
+        return delegate.executeQuery(identifier, sql, parameters, binders, mapper)
+    }
+
+    override fun executeUpdate(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqkonStatement.() -> Unit)?,
+    ): Long = delegate.executeUpdate(identifier, sql, parameters, binders)
+
+    override fun addListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
+        delegate.addListener(queryKeys = queryKeys, listener = listener)
+
+    override fun removeListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
+        delegate.removeListener(queryKeys = queryKeys, listener = listener)
+
+    override fun notifyListeners(vararg queryKeys: String) =
+        delegate.notifyListeners(queryKeys = queryKeys)
+
+    override fun newTransaction(): SqkonTransaction = delegate.newTransaction()
+    override fun currentTransaction(): SqkonTransaction? = delegate.currentTransaction()
+    override fun close() = delegate.close()
+
+    fun countMatching(fragment: String): Int = queries.count { it.contains(fragment) }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
@@ -436,4 +436,74 @@ class KeysetPagingTest {
             "All results should match the where clause"
         )
     }
+
+    @Test
+    fun keysetPaging_reportsAbsolutePositions_forPlaceholderSupport() = runTest {
+        // Regression for scroll-jump-on-append: keyset pages must report their
+        // absolute position (itemsBefore/itemsAfter) so a Pager with
+        // enablePlaceholders keeps ABSOLUTE list indices. Without it every page
+        // reports COUNT_UNDEFINED, Paging3 force-disables placeholders, LazyColumn
+        // indices become window-relative, and a RemoteMediator-write invalidation
+        // re-anchors the loaded window and jumps the user's scroll position.
+        val expected = (1..30).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, testObjectStorage.selectKeysetPagingSource(pageSize = 10))
+
+        val page1 = pager.refresh() as LoadResult.Page<String, TestObject>
+        assertEquals(0, page1.itemsBefore, "First page starts at absolute index 0")
+        assertEquals(20, page1.itemsAfter, "20 items remain after the first page of 30")
+
+        val page2 = pager.append() as LoadResult.Page<String, TestObject>
+        assertEquals(10, page2.itemsBefore, "Second page starts after the first 10 items")
+        assertEquals(10, page2.itemsAfter, "10 items remain after the second page")
+
+        val page3 = pager.append() as LoadResult.Page<String, TestObject>
+        assertEquals(20, page3.itemsBefore, "Third page starts after the first 20 items")
+        assertEquals(0, page3.itemsAfter, "No items remain after the final page")
+    }
+
+    @Test
+    fun keysetPaging_mediatorWrite_refreshedPageKnowsAbsolutePosition() = runTest {
+        // The scroll-jump root cause, end to end: user scrolls to page 3, a
+        // mediator-style write invalidates + shifts boundaries, and the fresh
+        // source's refresh must report the snapped page's ABSOLUTE offset so
+        // Paging3 can keep the anchor at its true index instead of jumping.
+        // Same fixture as keysetPaging_mediatorWriteDuringLoad_preservesAnchorPage:
+        // 50 rows + 5 injected = 55; anchor 25 snaps to the boundary at rn=21
+        // ("key-016") = the 3rd page = absolute offset 20.
+        val initial = (1..50).associate { i ->
+            val id = "key-${i.toString().padStart(3, '0')}"
+            id to TestObject(id = id, value = i)
+        }
+        testObjectStorage.insertAll(initial)
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val pagerA = TestPager(config, sourceA)
+        with(pagerA) { refresh(); append(); append() }
+        val state = pagerA.getPagingState(anchorPosition = 25)
+
+        val injected = (1..5).associate { i ->
+            val id = "key-005-injected-$i"
+            id to TestObject(id = id, value = 100 + i)
+        }
+        testObjectStorage.insertAll(injected)
+
+        val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val refreshKey = sourceB.getRefreshKey(state)
+        val page = sourceB.load(
+            PagingSource.LoadParams.Refresh(
+                key = refreshKey, loadSize = 10, placeholdersEnabled = true,
+            )
+        ) as LoadResult.Page<String, TestObject>
+
+        assertEquals("key-016", page.data.first().id, "Fixture invariant: snaps to page-3 boundary")
+        assertEquals(20, page.itemsBefore, "Refreshed page must report its absolute offset (20)")
+        assertEquals(
+            55, page.itemsBefore + page.data.size + page.itemsAfter,
+            "itemsBefore + loaded + itemsAfter must equal the full dataset count",
+        )
+    }
 }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingErrorHandlingTest.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingErrorHandlingTest.kt
@@ -65,6 +65,7 @@ class PagingErrorHandlingTest {
             queryProvider = entityQueries.selectKeyed("test-object"),
             pageBoundariesProvider = entityQueries.selectPageBoundaries("test-object"),
             boundaryForKeyProvider = entityQueries.selectBoundaryForKey("test-object"),
+            countQuery = entityQueries.count("test-object"),
             transacter = entityQueries,
             context = Dispatchers.IO,
             deserialize = { throw CancellationException("cancelled") },


### PR DESCRIPTION
## What

`KeysetQueryPagingSource` now reports `itemsBefore` / `itemsAfter` on its `LoadResult.Page`, mirroring `OffsetQueryPagingSource`. This lets consumers enable placeholders on a keyset source and keep **absolute** list indices.

## Why

A consumer paging a keyset source **with a `RemoteMediator`** (Mercury Android's merchants + spending-users lists) sees the scroll position jump every time a new page is appended.

Root cause:

1. `KeysetQueryPagingSource` only ever passed `data` / `prevKey` / `nextKey` to `LoadResult.Page`, so `itemsBefore` / `itemsAfter` defaulted to `COUNT_UNDEFINED`.
2. With no counts, Paging3 force-disables placeholders — list indices become relative to the currently-loaded window.
3. On every `APPEND`, the mediator writes to the entity table, which invalidates the source (SQLDelight table listener). Paging3 builds a fresh source and runs `REFRESH`, which re-anchors the window to a **page boundary**.
4. Because indices are window-relative, the consumer's saved scroll index (e.g. `LazyListState.firstVisibleItemIndex`) now maps to a different row → the visible jump into the newly-appended page.

Reporting real counts gives Paging3 absolute indices, so the saved position survives the re-anchor.

## How

Boundaries sit every `pageSize` rows, so the page at `keyIndex` starts at absolute row `keyIndex * pageSize`:

```kotlin
val count = countQuery.executeAsOne()
val itemsBefore = keyIndex * pageSize
LoadResult.Page(
    data = results,
    prevKey = previousKey,
    nextKey = nextKey,
    itemsBefore = itemsBefore,
    itemsAfter = maxOf(0, count - itemsBefore - results.size),
)
```

The count query is the same one `selectPagingSource` (offset) already uses: `entityQueries.count(entityName, where, expiresAfter)`.

## Compatibility

Backward compatible. Consumers with `enablePlaceholders = false` are unaffected — Paging3 ignores the counts for placeholder rendering until a consumer opts into `enablePlaceholders = true`. `jumpingSupported` is unchanged (`false`).

## Tests

Two new tests in `KeysetPagingTest` (both fail before this change, pass after):

- `keysetPaging_reportsAbsolutePositions_forPlaceholderSupport` — each page reports correct `itemsBefore` / `itemsAfter` across a 30-item dataset.
- `keysetPaging_mediatorWrite_refreshedPageKnowsAbsolutePosition` — reproduces the mediator-write-invalidation scenario and asserts the refreshed (snapped) page reports its true absolute offset.

`./gradlew :library:jvmTest` → 206 tests, 0 failures (offset + boundary suites unaffected).

## Downstream

Mercury Android will consume this and flip `enablePlaceholders = true` on `MerchantStore.pagingSource` and `BudgetStore.pagingSource` to eliminate the scroll jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
