### PR TITLE
perf(paging): halve paged-query volume; cache offset count per source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Compile iOS targets
         run: ./gradlew :library:compileKotlinIosArm64 :library:compileKotlinIosSimulatorArm64
 
-  paging-benchmark:
-    name: Paging benchmark (informational)
+  benchmark-suite:
+    name: Benchmark suite (informational)
     runs-on: ubuntu-latest
     # Informational only — never fails the build. The blocking perf gate is the query-count
     # guards in the jvm-tests job (KeysetPagingPerformanceTest / OffsetPagingPerformanceTest).
@@ -106,12 +106,12 @@ jobs:
           java-version: '21'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-      - name: Run paging benchmark
-        run: ./gradlew :library:jvmTest --tests "*PagingBenchmark" -Dsqkon.benchmark=true
+      - name: Run benchmark suite
+        run: ./gradlew :library:jvmTest --tests "*Benchmark" -Dsqkon.benchmark=true
       - name: Upload benchmark results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: paging-benchmark-results
-          path: library/build/benchmark-results/paging-benchmark.txt
+          name: benchmark-results
+          path: library/build/benchmark-results/
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,30 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Compile iOS targets
         run: ./gradlew :library:compileKotlinIosArm64 :library:compileKotlinIosSimulatorArm64
+
+  paging-benchmark:
+    name: Paging benchmark (informational)
+    runs-on: ubuntu-latest
+    # Informational only — never fails the build. The blocking perf gate is the query-count
+    # guards in the jvm-tests job (KeysetPagingPerformanceTest / OffsetPagingPerformanceTest).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup Java JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - name: Run paging benchmark
+        run: ./gradlew :library:jvmTest --tests "*PagingBenchmark" -Dsqkon.benchmark=true
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: paging-benchmark-results
+          path: library/build/benchmark-results/paging-benchmark.txt
+          if-no-files-found: warn

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -121,14 +121,15 @@ androidComponents {
     }
 }
 
-// The paging benchmark (PagingBenchmark) is skipped unless sqkon.benchmark=true. Gradle forks a
-// separate JVM for tests, so forward the property (and optional row count) into that JVM. Scoped to
-// jvmTest — the only task that runs the benchmark — so -Dsqkon.benchmark doesn't become an input on
-// unrelated Test tasks and churn their up-to-date/cache state.
+// The benchmark suite (*Benchmark classes) is skipped unless sqkon.benchmark=true. Gradle forks a
+// separate JVM for tests, so forward the flag (and the optional rows/warmup/runs knobs) into that
+// JVM. Scoped to jvmTest — the only task that runs the benchmarks — so -Dsqkon.benchmark doesn't
+// become an input on unrelated Test tasks and churn their up-to-date/cache state.
 tasks.withType<Test>().matching { it.name == "jvmTest" }.configureEach {
     systemProperty("sqkon.benchmark", providers.systemProperty("sqkon.benchmark").getOrElse("false"))
-    providers.systemProperty("sqkon.benchmark.rows").orNull
-        ?.let { systemProperty("sqkon.benchmark.rows", it) }
+    listOf("sqkon.benchmark.rows", "sqkon.benchmark.warmup", "sqkon.benchmark.runs").forEach { key ->
+        providers.systemProperty(key).orNull?.let { systemProperty(key, it) }
+    }
 }
 
 // MOB-3294: keep SQLDelight/eygraber imports out of the codebase after the androidx.sqlite

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -122,8 +122,10 @@ androidComponents {
 }
 
 // The paging benchmark (PagingBenchmark) is skipped unless sqkon.benchmark=true. Gradle forks a
-// separate JVM for tests, so forward the property (and optional row count) into that JVM.
-tasks.withType<Test>().configureEach {
+// separate JVM for tests, so forward the property (and optional row count) into that JVM. Scoped to
+// jvmTest — the only task that runs the benchmark — so -Dsqkon.benchmark doesn't become an input on
+// unrelated Test tasks and churn their up-to-date/cache state.
+tasks.withType<Test>().matching { it.name == "jvmTest" }.configureEach {
     systemProperty("sqkon.benchmark", providers.systemProperty("sqkon.benchmark").getOrElse("false"))
     providers.systemProperty("sqkon.benchmark.rows").orNull
         ?.let { systemProperty("sqkon.benchmark.rows", it) }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -121,6 +121,14 @@ androidComponents {
     }
 }
 
+// The paging benchmark (PagingBenchmark) is skipped unless sqkon.benchmark=true. Gradle forks a
+// separate JVM for tests, so forward the property (and optional row count) into that JVM.
+tasks.withType<Test>().configureEach {
+    systemProperty("sqkon.benchmark", providers.systemProperty("sqkon.benchmark").getOrElse("false"))
+    providers.systemProperty("sqkon.benchmark.rows").orNull
+        ?.let { systemProperty("sqkon.benchmark.rows", it) }
+}
+
 // MOB-3294: keep SQLDelight/eygraber imports out of the codebase after the androidx.sqlite
 // migration. Checks imports only, so the Apache-2.0 attribution KDoc that names the upstream
 // projects is left untouched. Wired into `check` and invoked directly in CI (see ci.yml).

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -338,15 +338,14 @@ open class KeyValueStorage<T : Any>(
                 limit = limit.toLong(),
                 offset = offset.toLong(),
                 expiresAt = expiresAfter,
-            ).also { entities ->
-                updateReadAt(entities.executeAsList().map { it.entity_key })
-            }
+            )
         },
         countQuery = entityQueries.count(entityName, where = where),
         transacter = entityQueries,
         context = readDispatcher,
         deserialize = { it.deserialize() },
         initialOffset = initialOffset,
+        onRowsLoaded = { entities -> updateReadAt(entities.map { it.entity_key }) },
     )
 
     /**

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -390,11 +390,7 @@ open class KeyValueStorage<T : Any>(
             expiresAt = expiresAfter,
         )
         return KeysetQueryPagingSource(
-            queryProvider = { begin, end ->
-                queryProvider(begin, end).also { query ->
-                    updateReadAt(query.executeAsList().map { it.entity_key })
-                }
-            },
+            queryProvider = queryProvider,
             pageBoundariesProvider = pageBoundariesProvider,
             boundaryForKeyProvider = boundaryForKeyProvider,
             countQuery = entityQueries.count(entityName, where = where, expiresAfter = expiresAfter),
@@ -402,6 +398,7 @@ open class KeyValueStorage<T : Any>(
             context = readDispatcher,
             deserialize = { it.deserialize() },
             pageSize = pageSize,
+            onRowsLoaded = { entities -> updateReadAt(entities.map { it.entity_key }) },
         )
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -35,6 +35,8 @@ import kotlin.coroutines.CoroutineContext
  * @param transacter Used to run queries within a transaction for consistency.
  * @param context Coroutine context for query execution.
  * @param deserialize Converts an [Entity] to the target type, returning null to skip.
+ * @param onRowsLoaded Invoked once per load with the raw rows fetched for the page (before
+ *   deserialize), so callers can mark them read without re-running the query.
  */
 internal class KeysetQueryPagingSource<T : Any>(
     private val queryProvider: (beginInclusive: String, endExclusive: String?) -> SqkonQuery<Entity>,
@@ -45,6 +47,7 @@ internal class KeysetQueryPagingSource<T : Any>(
     private val context: CoroutineContext,
     private val deserialize: (Entity) -> T?,
     private val pageSize: Int,
+    private val onRowsLoaded: (List<Entity>) -> Unit = {},
 ) : QueryPagingSource<String, T>() {
 
     private var pageBoundaries: List<String>? = null
@@ -107,10 +110,11 @@ internal class KeysetQueryPagingSource<T : Any>(
                         val previousKey = boundaries.getOrNull(keyIndex - 1)
                         val nextKey = boundaries.getOrNull(keyIndex + 1)
 
-                        val results = queryProvider(key, nextKey)
+                        val entities = queryProvider(key, nextKey)
                             .also { currentQuery = it }
                             .executeAsList()
-                            .mapNotNull { deserialize(it) }
+                        onRowsLoaded(entities)
+                        val results = entities.mapNotNull { deserialize(it) }
 
                         if (params.placeholdersEnabled) {
                             // Boundaries sit every pageSize rows, so page keyIndex starts at row

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -19,6 +19,10 @@ internal class OffsetQueryPagingSource<T : Any>(
     private val onRowsLoaded: (List<Entity>) -> Unit = {},
 ) : QueryPagingSource<Int, T>() {
 
+    // Computed once per source; any write invalidates the source, so the count is stable for
+    // its lifetime — same assumption KeysetQueryPagingSource.totalCount relies on (#117, #118).
+    private var totalCount: Int? = null
+
     override val jumpingSupported get() = true
 
     override suspend fun load(
@@ -32,7 +36,7 @@ internal class OffsetQueryPagingSource<T : Any>(
             }
             val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult.Page<Int, T> =
                 {
-                    val count = countQuery.executeAsOne()
+                    val count = totalCount ?: countQuery.executeAsOne().also { totalCount = it }
                     val offset = when (params) {
                         is PagingSource.LoadParams.Prepend<*> -> maxOf(0, key - params.loadSize)
                         is PagingSource.LoadParams.Append<*> -> key

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -16,6 +16,7 @@ internal class OffsetQueryPagingSource<T : Any>(
     private val context: CoroutineContext,
     private val deserialize: (Entity) -> T?,
     private val initialOffset: Int,
+    private val onRowsLoaded: (List<Entity>) -> Unit = {},
 ) : QueryPagingSource<Int, T>() {
 
     override val jumpingSupported get() = true
@@ -41,10 +42,11 @@ internal class OffsetQueryPagingSource<T : Any>(
 
                         else -> error("Unknown PagingSourceLoadParams ${params::class}")
                     }
-                    val data = queryProvider(limit, offset)
+                    val entities = queryProvider(limit, offset)
                         .also { currentQuery = it }
                         .executeAsList()
-                        .mapNotNull { deserialize(it) }
+                    onRowsLoaded(entities)
+                    val data = entities.mapNotNull { deserialize(it) }
                     val nextPosToLoad = offset + data.size
                     PagingSource.LoadResult.Page(
                         data = data,

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/CountingDriver.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/CountingDriver.kt
@@ -1,0 +1,50 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.db.internal.SqkonCursor
+import com.mercury.sqkon.db.internal.SqkonDriver
+import com.mercury.sqkon.db.internal.SqkonStatement
+import com.mercury.sqkon.db.internal.SqkonTransaction
+
+/**
+ * Delegating [SqkonDriver] that records the SQL of every `executeQuery` for assertions.
+ *
+ * Shared by the paging performance guards ([KeysetPagingPerformanceTest],
+ * [OffsetPagingPerformanceTest]) to count actual SQL executions deterministically — no timing,
+ * no flakiness. Wrap a real driver: `CountingDriver(driverFactory().createDriver())`.
+ */
+internal class CountingDriver(private val delegate: SqkonDriver) : SqkonDriver {
+    val queries = mutableListOf<String>()
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqkonStatement.() -> Unit)?,
+        mapper: (SqkonCursor) -> R,
+    ): R {
+        queries += sql
+        return delegate.executeQuery(identifier, sql, parameters, binders, mapper)
+    }
+
+    override fun executeUpdate(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqkonStatement.() -> Unit)?,
+    ): Long = delegate.executeUpdate(identifier, sql, parameters, binders)
+
+    override fun addListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
+        delegate.addListener(queryKeys = queryKeys, listener = listener)
+
+    override fun removeListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
+        delegate.removeListener(queryKeys = queryKeys, listener = listener)
+
+    override fun notifyListeners(vararg queryKeys: String) =
+        delegate.notifyListeners(queryKeys = queryKeys)
+
+    override fun newTransaction(): SqkonTransaction = delegate.newTransaction()
+    override fun currentTransaction(): SqkonTransaction? = delegate.currentTransaction()
+    override fun close() = delegate.close()
+
+    fun countMatching(fragment: String): Int = queries.count { it.contains(fragment) }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
@@ -4,10 +4,6 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.testing.TestPager
 import com.mercury.sqkon.TestObject
-import com.mercury.sqkon.db.internal.SqkonCursor
-import com.mercury.sqkon.db.internal.SqkonDriver
-import com.mercury.sqkon.db.internal.SqkonStatement
-import com.mercury.sqkon.db.internal.SqkonTransaction
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
@@ -81,42 +77,4 @@ class KeysetPagingPerformanceTest {
         )
         assertEquals(10, last.data.size, "fixture: full final page")
     }
-}
-
-/** Delegating [SqkonDriver] that records the SQL of every executeQuery for assertions. */
-private class CountingDriver(private val delegate: SqkonDriver) : SqkonDriver {
-    val queries = mutableListOf<String>()
-
-    override fun <R> executeQuery(
-        identifier: Int?,
-        sql: String,
-        parameters: Int,
-        binders: (SqkonStatement.() -> Unit)?,
-        mapper: (SqkonCursor) -> R,
-    ): R {
-        queries += sql
-        return delegate.executeQuery(identifier, sql, parameters, binders, mapper)
-    }
-
-    override fun executeUpdate(
-        identifier: Int?,
-        sql: String,
-        parameters: Int,
-        binders: (SqkonStatement.() -> Unit)?,
-    ): Long = delegate.executeUpdate(identifier, sql, parameters, binders)
-
-    override fun addListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
-        delegate.addListener(queryKeys = queryKeys, listener = listener)
-
-    override fun removeListener(vararg queryKeys: String, listener: SqkonDriver.Listener) =
-        delegate.removeListener(queryKeys = queryKeys, listener = listener)
-
-    override fun notifyListeners(vararg queryKeys: String) =
-        delegate.notifyListeners(queryKeys = queryKeys)
-
-    override fun newTransaction(): SqkonTransaction = delegate.newTransaction()
-    override fun currentTransaction(): SqkonTransaction? = delegate.currentTransaction()
-    override fun close() = delegate.close()
-
-    fun countMatching(fragment: String): Int = queries.count { it.contains(fragment) }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingPerformanceTest.kt
@@ -77,4 +77,20 @@ class KeysetPagingPerformanceTest {
         )
         assertEquals(10, last.data.size, "fixture: full final page")
     }
+
+    @Test
+    fun pageQuery_runsOncePerPageLoad_notTwice() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = 10))
+
+        driver.queries.clear()
+        with(pager) { refresh(); append(); append() } // 3 page loads on ONE source
+
+        // "WHERE rn >=" is unique to the keyed data query (selectKeyed), not boundaries/snap.
+        assertEquals(
+            3, driver.countMatching("WHERE rn >="),
+            "keyed page query must run once per page load (3 loads), not twice",
+        )
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingPerformanceTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingPerformanceTest.kt
@@ -1,0 +1,47 @@
+package com.mercury.sqkon.db
+
+import androidx.paging.PagingConfig
+import androidx.paging.testing.TestPager
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Performance regression guards for offset paging: the page-data query must run ONCE per page
+ * load (not twice — read-tracking must not re-execute it) and the total-count query must run ONCE
+ * per PagingSource (not once per page load). Uses [CountingDriver] to count SQL — deterministic,
+ * no timing.
+ */
+class OffsetPagingPerformanceTest {
+
+    private val mainScope = MainScope()
+    private val driver = CountingDriver(driverFactory().createDriver())
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() = mainScope.cancel()
+
+    @Test
+    fun pageQuery_runsOncePerPageLoad_notTwice() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, storage.selectPagingSource())
+
+        driver.queries.clear() // ignore insert/setup SQL
+        with(pager) { refresh(); append(); append() } // 3 page loads on ONE source
+
+        // "OFFSET ?" is unique to the offset data query (select), not the count query.
+        assertEquals(
+            3, driver.countMatching("OFFSET ?"),
+            "offset page query must run once per page load (3 loads), not twice",
+        )
+    }
+}

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingPerformanceTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingPerformanceTest.kt
@@ -44,4 +44,19 @@ class OffsetPagingPerformanceTest {
             "offset page query must run once per page load (3 loads), not twice",
         )
     }
+
+    @Test
+    fun countQuery_runsOncePerSource_notPerPageLoad() = runTest {
+        storage.insertAll((1..100).map { TestObject() }.associateBy { it.id })
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, storage.selectPagingSource())
+
+        driver.queries.clear() // ignore insert/setup SQL
+        with(pager) { refresh(); append(); append() } // 3 page loads on ONE source
+
+        assertEquals(
+            1, driver.countMatching("COUNT(DISTINCT"),
+            "total-count query must run once per source, not once per page load",
+        )
+    }
 }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/Benchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/Benchmark.kt
@@ -1,0 +1,105 @@
+package com.mercury.sqkon.db
+
+import org.junit.Assume.assumeTrue
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.measureTime
+
+/**
+ * Shared, dependency-free harness for the sqkon informational benchmark suite.
+ *
+ * Every benchmark class extends [BenchmarkSuite] and drives its cases through a [BenchmarkRunner],
+ * which does `warmup` discarded iterations + `runs` measured iterations and writes one results file
+ * per class under `build/benchmark-results/`. The suite is opt-in — each `@Test` starts with
+ * [assumeBenchmarkEnabled], so it is skipped in the normal `jvmTest` gate and only runs when
+ * `-Dsqkon.benchmark=true` is passed (see the `benchmark-suite` CI job).
+ *
+ * Deliberately dependency-free (kotlin.time + java.io.File + JUnit assumeTrue only). kotlinx-benchmark's
+ * Gradle plugin bundles a Kotlin compiler plugin and does not state Kotlin 2.3 support (its latest
+ * release targets Kotlin 2.2.0), so it is a build-breakage risk on this repo's Kotlin 2.3.21. Once
+ * kotlinx-benchmark supports Kotlin 2.3, these can be promoted to real JMH benchmarks.
+ *
+ * Tunables (all optional JVM system properties, forwarded to the jvmTest JVM by build.gradle.kts):
+ *   -Dsqkon.benchmark=true        enable the suite (required; skipped otherwise)
+ *   -Dsqkon.benchmark.rows=N      dataset size (default 2000)
+ *   -Dsqkon.benchmark.warmup=N    discarded warmup iterations per case (default 2)
+ *   -Dsqkon.benchmark.runs=N      measured iterations per case (default 5)
+ */
+fun assumeBenchmarkEnabled() = assumeTrue(
+    "set -Dsqkon.benchmark=true to run benchmarks",
+    System.getProperty("sqkon.benchmark") == "true",
+)
+
+fun benchmarkRows(): Int = System.getProperty("sqkon.benchmark.rows")?.toIntOrNull() ?: 2000
+
+fun benchmarkWarmup(): Int = System.getProperty("sqkon.benchmark.warmup")?.toIntOrNull() ?: 2
+
+fun benchmarkRuns(): Int = System.getProperty("sqkon.benchmark.runs")?.toIntOrNull() ?: 5
+
+/** One measured case: [total] is the summed wall time across [runs] iterations. */
+data class BenchResult(
+    val label: String,
+    val runs: Int,
+    val opsPerIter: Int,
+    val total: Duration,
+) {
+    val perIter: Duration get() = total / runs
+    val totalOps: Long get() = runs.toLong() * opsPerIter
+    val opsPerSec: Double
+        get() = if (total.inWholeNanoseconds == 0L) 0.0
+        else totalOps / total.toDouble(DurationUnit.SECONDS)
+}
+
+/**
+ * Runs benchmark cases and accumulates their results. [opsPerIter] is the number of logical
+ * operations in a single `block()` call, so `ops_per_sec` is comparable across cases regardless of
+ * how much each case does per iteration. [BenchmarkRunner.bench]'s optional `reset` runs untimed
+ * before every iteration (warmup and measured) — use it for mutating cases that must start each
+ * iteration from a known state.
+ */
+class BenchmarkRunner(
+    private val suite: String,
+    private val warmup: Int = benchmarkWarmup(),
+    private val runs: Int = benchmarkRuns(),
+) {
+    private val results = mutableListOf<BenchResult>()
+
+    suspend fun bench(
+        label: String,
+        opsPerIter: Int,
+        reset: (suspend () -> Unit)? = null,
+        block: suspend () -> Unit,
+    ) {
+        repeat(warmup) { reset?.invoke(); block() }
+        var total = Duration.ZERO
+        repeat(runs) {
+            reset?.invoke()
+            total += measureTime { block() }
+        }
+        results += BenchResult(label, runs, opsPerIter, total)
+    }
+
+    /** Writes `build/benchmark-results/<suite>.txt` and echoes it to stdout. Call once at the end. */
+    fun report(meta: Map<String, Any> = emptyMap()) {
+        val text = renderReport(suite, results, meta)
+        println(text)
+        File("build/benchmark-results").apply { mkdirs() }
+            .resolve("$suite.txt").writeText(text)
+    }
+}
+
+/** One `case=… per_iter_ms=… ops_per_sec=…` line per result — human-scannable and greppable. */
+fun renderReport(suite: String, results: List<BenchResult>, meta: Map<String, Any>): String =
+    buildString {
+        appendLine("sqkon benchmark: $suite")
+        if (meta.isNotEmpty()) appendLine(meta.entries.joinToString(" ") { "${it.key}=${it.value}" })
+        results.forEach { r ->
+            val perIterMs = r.perIter.inWholeMicroseconds / 1000.0
+            val totalMs = r.total.inWholeMicroseconds / 1000.0
+            appendLine(
+                "case=${r.label} runs=${r.runs} ops_per_iter=${r.opsPerIter} " +
+                    "per_iter_ms=$perIterMs total_ms=$totalMs ops_per_sec=${r.opsPerSec.toLong()}"
+            )
+        }
+    }

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/BenchmarkSuite.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/BenchmarkSuite.kt
@@ -1,0 +1,41 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import org.junit.After
+
+/**
+ * Base class for the benchmark suite. Owns the in-memory fixtures every case needs — a [MainScope],
+ * an in-memory driver, [EntityQueries]/[MetadataQueries], a [KeyValueStorage] of [TestObject], and a
+ * [BenchmarkRunner] — plus the `@After` teardown and a deterministic [seedObjects] helper, so each
+ * concrete benchmark class is just its cases.
+ *
+ * The opt-in gate ([assumeBenchmarkEnabled]) is called at the top of each concrete `@Test`, not in
+ * `@Before`, so it composes inside `runTest {}` and the classes still compile/skip cleanly under the
+ * normal `jvmTest` gate.
+ */
+abstract class BenchmarkSuite(suiteName: String) {
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+
+    protected val storage: KeyValueStorage<TestObject> =
+        keyValueStorage<TestObject>(suiteName, entityQueries, metadataQueries, mainScope)
+    protected val runner = BenchmarkRunner(suiteName)
+
+    @After
+    fun tearDown() = mainScope.cancel()
+
+    /**
+     * Deterministic, zero-padded, sortable keys (`key-000001`..) with `value = i` and an even/odd
+     * `name`, so where/orderBy cases have predictable selectivity across runs. Returns the map ready
+     * for `insertAll`.
+     */
+    protected fun seedObjects(n: Int): Map<String, TestObject> =
+        (1..n).associate { i ->
+            val id = "key-" + i.toString().padStart(6, '0')
+            id to TestObject(id = id, value = i, name = if (i % 2 == 0) "even" else "odd")
+        }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/CountDeleteBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/CountDeleteBenchmark.kt
@@ -1,0 +1,47 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Count + delete suite: `COUNT(DISTINCT)` with and without a WHERE join, and the delete paths
+ * (by-where, by-key batch, truncate-all). Count cases are read-only (seed once); delete cases mutate,
+ * so `reset` re-seeds untimed before each iteration. See [Benchmark] for how the suite runs.
+ */
+class CountDeleteBenchmark : BenchmarkSuite("count-delete") {
+
+    @Test
+    fun benchmark() = runTest {
+        assumeBenchmarkEnabled()
+        val rows = benchmarkRows()
+        val seed = seedObjects(rows)
+        val hotKeys = seed.keys.take(100).toTypedArray()
+
+        // Count cases: read-only, seed once.
+        storage.insertAll(seed)
+        // Count cases report counts/sec (opsPerIter=1): one COUNT(DISTINCT) call over the full table.
+        runner.bench("count_all", opsPerIter = 1) {
+            storage.count().first()
+        }
+        runner.bench("count_where", opsPerIter = 1) {
+            storage.count(where = TestObject::value gt (rows / 2)).first()
+        }
+
+        // Delete cases report rows/sec (opsPerIter = rows actually removed), so the three are
+        // comparable. Mutating, so re-seed untimed before each iteration.
+        val reseed: suspend () -> Unit = { storage.deleteAll(); storage.insertAll(seed) }
+        runner.bench("delete_where", opsPerIter = rows / 2, reset = reseed) {
+            // name eq "even" matches the even-indexed half of the seed
+            storage.delete(where = TestObject::name eq "even")
+        }
+        runner.bench("deleteByKeys_batch", opsPerIter = hotKeys.size, reset = reseed) {
+            storage.deleteByKeys(*hotKeys)
+        }
+        runner.bench("deleteAll", opsPerIter = rows, reset = reseed) {
+            storage.deleteAll()
+        }
+        runner.report(mapOf("rows" to rows))
+    }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
@@ -1,0 +1,95 @@
+package com.mercury.sqkon.db
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource.LoadResult
+import androidx.paging.testing.TestPager
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import kotlin.time.measureTime
+
+/**
+ * Informational paging timing benchmark for trend visibility — NOT a correctness test and NOT a
+ * hard regression gate (the deterministic query-count guards in KeysetPagingPerformanceTest /
+ * OffsetPagingPerformanceTest are the build-failing guardrails).
+ *
+ * Skipped by default so it never slows the blocking `jvmTest` gate. Run it explicitly:
+ *   ./gradlew :library:jvmTest --tests "*PagingBenchmark" -Dsqkon.benchmark=true
+ * Optionally set the dataset size with -Dsqkon.benchmark.rows=5000 (default 2000).
+ * Results are written to library/build/benchmark-results/paging-benchmark.txt and echoed to stdout.
+ *
+ * Deliberately dependency-free (kotlin.time + nanoTime, no JMH). kotlinx-benchmark's Gradle plugin
+ * bundles a Kotlin compiler plugin and does not state Kotlin 2.3 support (its latest release
+ * targets Kotlin 2.2.0), so it is a build-breakage risk on this repo's Kotlin 2.3.21. Once
+ * kotlinx-benchmark supports Kotlin 2.3, this can be promoted to a real JMH benchmark.
+ */
+class PagingBenchmark {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val storage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() = mainScope.cancel()
+
+    @Test
+    fun pagingThroughput() = runTest {
+        assumeTrue(
+            "set -Dsqkon.benchmark=true to run the paging benchmark",
+            System.getProperty("sqkon.benchmark") == "true",
+        )
+        val rows = System.getProperty("sqkon.benchmark.rows")?.toIntOrNull() ?: 2000
+        val pageSize = 50
+        storage.insertAll((1..rows).map { TestObject() }.associateBy { it.id })
+
+        // Warmup (let the JIT settle) — page fully through once per source type; timing discarded.
+        pageThroughKeyset(pageSize)
+        pageThroughOffset(pageSize)
+
+        val runs = 3
+        val keysetTime = measureTime { repeat(runs) { pageThroughKeyset(pageSize) } }
+        val offsetTime = measureTime { repeat(runs) { pageThroughOffset(pageSize) } }
+
+        val report = buildString {
+            appendLine("sqkon paging benchmark")
+            appendLine("rows=$rows pageSize=$pageSize runs=$runs")
+            appendLine("keyset_total_ms=${keysetTime.inWholeMilliseconds}")
+            appendLine("offset_total_ms=${offsetTime.inWholeMilliseconds}")
+        }
+        println(report)
+        File("build/benchmark-results").apply { mkdirs() }
+            .resolve("paging-benchmark.txt").writeText(report)
+    }
+
+    // Pages from the first page to the end on a single source. The loop stops on the first
+    // non-Page / empty append result, so it is robust whether TestPager.append() signals
+    // end-of-list by returning null or by returning an empty final Page.
+    private suspend fun pageThroughKeyset(pageSize: Int) {
+        val config = PagingConfig(pageSize = pageSize, prefetchDistance = 0, initialLoadSize = pageSize)
+        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = pageSize))
+        pager.refresh()
+        var next = pager.append()
+        while (next is LoadResult.Page && next.data.isNotEmpty()) {
+            next = pager.append()
+        }
+    }
+
+    private suspend fun pageThroughOffset(pageSize: Int) {
+        val config = PagingConfig(pageSize = pageSize, prefetchDistance = 0, initialLoadSize = pageSize)
+        val pager = TestPager(config, storage.selectPagingSource())
+        pager.refresh()
+        var next = pager.append()
+        while (next is LoadResult.Page && next.data.isNotEmpty()) {
+            next = pager.append()
+        }
+    }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
@@ -5,74 +5,31 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.testing.TestPager
 import com.mercury.sqkon.TestObject
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Assume.assumeTrue
 import org.junit.Test
-import java.io.File
-import kotlin.time.measureTime
 
 /**
- * Informational paging timing benchmark for trend visibility — NOT a correctness test and NOT a
- * hard regression gate (the deterministic query-count guards in KeysetPagingPerformanceTest /
- * OffsetPagingPerformanceTest are the build-failing guardrails).
- *
- * Skipped by default so it never slows the blocking `jvmTest` gate. Run it explicitly:
- *   ./gradlew :library:jvmTest --tests "*PagingBenchmark" -Dsqkon.benchmark=true
- * Optionally set the dataset size with -Dsqkon.benchmark.rows=5000 (default 2000).
- * Results are written to library/build/benchmark-results/paging-benchmark.txt and echoed to stdout.
- *
- * Deliberately dependency-free (kotlin.time + nanoTime, no JMH). kotlinx-benchmark's Gradle plugin
- * bundles a Kotlin compiler plugin and does not state Kotlin 2.3 support (its latest release
- * targets Kotlin 2.2.0), so it is a build-breakage risk on this repo's Kotlin 2.3.21. Once
- * kotlinx-benchmark supports Kotlin 2.3, this can be promoted to a real JMH benchmark.
+ * Paging suite: pages fully through the dataset with each PagingSource. Exercises the O(n)
+ * `ROW_NUMBER()` window keyset recomputes per page vs. SQL `OFFSET`'s per-page scan — the headline
+ * paging cost this whole benchmark effort exists to track. See [Benchmark] for how the suite runs.
  */
-class PagingBenchmark {
-
-    private val mainScope = MainScope()
-    private val driver = driverFactory().createDriver()
-    private val entityQueries = EntityQueries(driver)
-    private val metadataQueries = MetadataQueries(driver)
-    private val storage = keyValueStorage<TestObject>(
-        "test-object", entityQueries, metadataQueries, mainScope
-    )
-
-    @After
-    fun tearDown() = mainScope.cancel()
+class PagingBenchmark : BenchmarkSuite("paging") {
 
     @Test
-    fun pagingThroughput() = runTest {
-        assumeTrue(
-            "set -Dsqkon.benchmark=true to run the paging benchmark",
-            System.getProperty("sqkon.benchmark") == "true",
-        )
-        val rows = System.getProperty("sqkon.benchmark.rows")?.toIntOrNull() ?: 2000
+    fun benchmark() = runTest {
+        assumeBenchmarkEnabled()
+        val rows = benchmarkRows()
         val pageSize = 50
-        storage.insertAll((1..rows).map { TestObject() }.associateBy { it.id })
+        val pages = (rows + pageSize - 1) / pageSize // ceil(rows / pageSize): page-loads per drain
+        storage.insertAll(seedObjects(rows))
 
-        // Warmup (let the JIT settle) — page fully through once per source type; timing discarded.
-        pageThrough(pageSize) { storage.selectKeysetPagingSource(pageSize = pageSize) }
-        pageThrough(pageSize) { storage.selectPagingSource() }
-
-        val runs = 3
-        val keysetTime = measureTime {
-            repeat(runs) { pageThrough(pageSize) { storage.selectKeysetPagingSource(pageSize = pageSize) } }
+        runner.bench("keyset_page_through", opsPerIter = pages) {
+            pageThrough(pageSize) { storage.selectKeysetPagingSource(pageSize = pageSize) }
         }
-        val offsetTime = measureTime {
-            repeat(runs) { pageThrough(pageSize) { storage.selectPagingSource() } }
+        runner.bench("offset_page_through", opsPerIter = pages) {
+            pageThrough(pageSize) { storage.selectPagingSource() }
         }
-
-        val report = buildString {
-            appendLine("sqkon paging benchmark")
-            appendLine("rows=$rows pageSize=$pageSize runs=$runs")
-            appendLine("keyset_total_ms=${keysetTime.inWholeMilliseconds}")
-            appendLine("offset_total_ms=${offsetTime.inWholeMilliseconds}")
-        }
-        println(report)
-        File("build/benchmark-results").apply { mkdirs() }
-            .resolve("paging-benchmark.txt").writeText(report)
+        runner.report(mapOf("rows" to rows, "pageSize" to pageSize))
     }
 
     // Pages from the first page to the end on a single source produced by [source]. The loop stops

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/PagingBenchmark.kt
@@ -1,6 +1,7 @@
 package com.mercury.sqkon.db
 
 import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.testing.TestPager
 import com.mercury.sqkon.TestObject
@@ -52,12 +53,16 @@ class PagingBenchmark {
         storage.insertAll((1..rows).map { TestObject() }.associateBy { it.id })
 
         // Warmup (let the JIT settle) — page fully through once per source type; timing discarded.
-        pageThroughKeyset(pageSize)
-        pageThroughOffset(pageSize)
+        pageThrough(pageSize) { storage.selectKeysetPagingSource(pageSize = pageSize) }
+        pageThrough(pageSize) { storage.selectPagingSource() }
 
         val runs = 3
-        val keysetTime = measureTime { repeat(runs) { pageThroughKeyset(pageSize) } }
-        val offsetTime = measureTime { repeat(runs) { pageThroughOffset(pageSize) } }
+        val keysetTime = measureTime {
+            repeat(runs) { pageThrough(pageSize) { storage.selectKeysetPagingSource(pageSize = pageSize) } }
+        }
+        val offsetTime = measureTime {
+            repeat(runs) { pageThrough(pageSize) { storage.selectPagingSource() } }
+        }
 
         val report = buildString {
             appendLine("sqkon paging benchmark")
@@ -70,22 +75,12 @@ class PagingBenchmark {
             .resolve("paging-benchmark.txt").writeText(report)
     }
 
-    // Pages from the first page to the end on a single source. The loop stops on the first
-    // non-Page / empty append result, so it is robust whether TestPager.append() signals
-    // end-of-list by returning null or by returning an empty final Page.
-    private suspend fun pageThroughKeyset(pageSize: Int) {
+    // Pages from the first page to the end on a single source produced by [source]. The loop stops
+    // on the first non-Page / empty append result, so it is robust whether TestPager.append()
+    // signals end-of-list by returning null or by returning an empty final Page.
+    private suspend fun <K : Any> pageThrough(pageSize: Int, source: () -> PagingSource<K, TestObject>) {
         val config = PagingConfig(pageSize = pageSize, prefetchDistance = 0, initialLoadSize = pageSize)
-        val pager = TestPager(config, storage.selectKeysetPagingSource(pageSize = pageSize))
-        pager.refresh()
-        var next = pager.append()
-        while (next is LoadResult.Page && next.data.isNotEmpty()) {
-            next = pager.append()
-        }
-    }
-
-    private suspend fun pageThroughOffset(pageSize: Int) {
-        val config = PagingConfig(pageSize = pageSize, prefetchDistance = 0, initialLoadSize = pageSize)
-        val pager = TestPager(config, storage.selectPagingSource())
+        val pager = TestPager(config, source())
         pager.refresh()
         var next = pager.append()
         while (next is LoadResult.Page && next.data.isNotEmpty()) {

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/ReadBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/ReadBenchmark.kt
@@ -1,0 +1,54 @@
+package com.mercury.sqkon.db
+
+import com.mercury.sqkon.TestObject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Read suite: full-table hydrate, indexed key lookups, and json-query where-scans at varying
+ * selectivity and path shape. Note: every top-level `select(where = …)` predicate lowers to the same
+ * engine strategy — a `json_tree` tree-walk of each row plus a `fullkey LIKE` (the scalar
+ * `json_extract` form is only used inside CASE expressions, never from `select`). So the where cases
+ * below vary the matched path and match count, not the query strategy (issue #68). Dataset is seeded
+ * once; all cases are read-only so no reset is needed. Reads are `Flow`-based, collected with
+ * `.first()`. See [Benchmark] for how the suite runs.
+ */
+class ReadBenchmark : BenchmarkSuite("read") {
+
+    @Test
+    fun benchmark() = runTest {
+        assumeBenchmarkEnabled()
+        val rows = benchmarkRows()
+        val seed = seedObjects(rows)
+        storage.insertAll(seed)
+        val hotKeys = seed.keys.take(100).toList()
+
+        runner.bench("selectAll", opsPerIter = rows) {
+            storage.selectAll().first()
+        }
+        runner.bench("selectByKey_hot", opsPerIter = hotKeys.size) {
+            hotKeys.forEach { key -> storage.selectByKey(key).first() }
+        }
+        runner.bench("selectByKeys_batch", opsPerIter = hotKeys.size) {
+            storage.selectByKeys(hotKeys).first()
+        }
+        runner.bench("where_int_eq_1match", opsPerIter = rows) {
+            // top-level Int field, matches ~1 row — highly selective json_tree where-scan
+            storage.select(where = TestObject::value eq (rows / 2)).first()
+        }
+        runner.bench("where_string_eq_halfmatch", opsPerIter = rows) {
+            // top-level String field, matches ~half the rows
+            storage.select(where = TestObject::name eq "even").first()
+        }
+        runner.bench("where_list_contains_allmatch", opsPerIter = rows) {
+            // attributes is a List<String> (defaults to "1".."10"); a collection-element where that
+            // matches every row — the worst-case json_tree fan-out shape (issue #68).
+            storage.select(where = TestObject::attributes eq "5").first()
+        }
+        runner.bench("select_ordered_scan", opsPerIter = rows) {
+            storage.select(orderBy = listOf(OrderBy(TestObject::value, OrderDirection.DESC))).first()
+        }
+        runner.report(mapOf("rows" to rows))
+    }
+}

--- a/library/src/jvmTest/kotlin/com/mercury/sqkon/db/WriteBenchmark.kt
+++ b/library/src/jvmTest/kotlin/com/mercury/sqkon/db/WriteBenchmark.kt
@@ -1,0 +1,39 @@
+package com.mercury.sqkon.db
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Write suite: bulk vs. single-row insert throughput, plus the update and upsert merge paths.
+ * `reset` re-establishes the starting state before each iteration, untimed, so only the write path
+ * under test is measured. ops/sec reads as rows/sec. See [Benchmark] for how the suite runs.
+ */
+class WriteBenchmark : BenchmarkSuite("write") {
+
+    @Test
+    fun benchmark() = runTest {
+        assumeBenchmarkEnabled()
+        val rows = benchmarkRows()
+        val seed = seedObjects(rows)
+
+        runner.bench("insertAll_bulk", opsPerIter = rows, reset = { storage.deleteAll() }) {
+            storage.insertAll(seed)
+        }
+        runner.bench("insert_loop_single", opsPerIter = rows, reset = { storage.deleteAll() }) {
+            seed.forEach { (key, value) -> storage.insert(key, value) }
+        }
+        runner.bench(
+            "updateAll_bulk", opsPerIter = rows,
+            reset = { storage.deleteAll(); storage.insertAll(seed) },
+        ) {
+            storage.updateAll(seed)
+        }
+        runner.bench(
+            "upsertAll_bulk", opsPerIter = rows,
+            reset = { storage.deleteAll(); storage.insertAll(seed) },
+        ) {
+            storage.upsertAll(seed)
+        }
+        runner.report(mapOf("rows" to rows))
+    }
+}


### PR DESCRIPTION
## Summary

Performance fixes for the paging subsystem. Closes #118. Follow-up to #117 (now merged).

- **Page query ran twice per page load.** Both the keyset and offset `PagingSource`s executed the page-data query once to harvest `entity_key`s for read-tracking, then again for the data. A new `onRowsLoaded(List<Entity>)` hook now marks rows read from the list the source already fetched — **one query per page load**. Read-tracking parity is preserved: keys are harvested from the raw entities *before* `deserialize` can drop any.
- **Offset re-ran `COUNT(DISTINCT)` on every page load.** Now cached once per source, mirroring keyset's `totalCount` (#117). Safe under the same invalidation model — any write invalidates the source, so the count is stable within a source's lifetime.

Both changes are performance-only; paged data, read-tracking, counts and scroll positions are unchanged.

## Performance regression tooling

- **Blocking:** deterministic query-count guards (`KeysetPagingPerformanceTest`, `OffsetPagingPerformanceTest`) via a shared `CountingDriver` that counts real SQL executions — they assert the page query runs once per load and the count runs once per source. These run in the existing `jvm-tests` CI job.
- **Informational:** an opt-in, dependency-free JVM timing benchmark (`PagingBenchmark`, run with `-Dsqkon.benchmark=true`, skipped otherwise) plus a **non-blocking** `paging-benchmark` CI job that uploads results for trend visibility. Deliberately not kotlinx-benchmark/JMH — its Gradle plugin bundles a Kotlin compiler plugin with no stated Kotlin 2.3 support, a build-breakage risk on this repo's Kotlin 2.3.21.

## Testing

`./gradlew checkNoSqlDelightImports jvmTest` → BUILD SUCCESSFUL. New guards cover: keyset page-query-once, offset page-query-once, offset count-once (each written RED→GREEN).

## Notes

- Reviewed via multi-agent code-review (high effort) + a simplification pass.
- One follow-up filed: #119 — read-tracking fires on loads later discarded as `Invalid`. Pre-existing behavior (predates this PR, shipped via #117); out of scope for a performance-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)