### PR TITLE
docs: clarify offset paging count-cache invalidation comment

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -19,8 +19,12 @@ internal class OffsetQueryPagingSource<T : Any>(
     private val onRowsLoaded: (List<Entity>) -> Unit = {},
 ) : QueryPagingSource<Int, T>() {
 
-    // Computed once per source; any write invalidates the source, so the count is stable for
-    // its lifetime — same assumption KeysetQueryPagingSource.totalCount relies on (#117, #118).
+    // Computed once per source. The DISTINCT-entity count only changes when the rowset changes
+    // (insert/delete/upsert), and those writes notify entityKey(entityName), invalidating this
+    // source so the Pager builds a fresh one that recomputes. read_at writes deliberately notify
+    // only ALL_ENTITIES_KEY (not entityKey) to avoid re-waking paging, so they neither invalidate
+    // this source nor change the count — the cached value stays valid for the source's lifetime.
+    // Same assumption KeysetQueryPagingSource.totalCount relies on (#117, #118).
     private var totalCount: Int? = null
 
     override val jumpingSupported get() = true


### PR DESCRIPTION
Addresses the Copilot review comment on #120.

The `OffsetQueryPagingSource.totalCount` comment claimed "any write invalidates the source". That's misleading: `read_at` writes deliberately notify only `ALL_ENTITIES_KEY` (not `entityKey(entityName)`) to avoid re-waking the paging source (see `MetadataQueries.notifyEntityReadAtChanged`), so they do **not** invalidate it. Only rowset-changing writes (insert/delete/upsert) notify `entityKey(entityName)` and invalidate the source — which is exactly what keeps the cached count valid within a source's lifetime.

Comment-only change; no logic or behavior change. `./gradlew checkNoSqlDelightImports jvmTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)