### PR TITLE
fix(paging): defer read-tracking past Invalid check (#119) + apply expiresAfter to offset count

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/KeyValueStorage.kt
@@ -340,7 +340,7 @@ open class KeyValueStorage<T : Any>(
                 expiresAt = expiresAfter,
             )
         },
-        countQuery = entityQueries.count(entityName, where = where),
+        countQuery = entityQueries.count(entityName, where = where, expiresAfter = expiresAfter),
         transacter = entityQueries,
         context = readDispatcher,
         deserialize = { it.deserialize() },

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -59,6 +59,10 @@ internal class KeysetQueryPagingSource<T : Any>(
         params: PagingSource.LoadParams<String>,
     ): PagingSource.LoadResult<String, T> = withContext(context) {
         loadResultCatching {
+            // Rows fetched inside the transaction, hoisted so read-tracking runs *after* the
+            // invalid check below — a load discarded as Invalid must not mark rows read (#119).
+            // Stays null when no page query ran (empty boundaries).
+            var loadedRows: List<Entity>? = null
             val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult<String, T> =
                 {
                     // Always use the stable pageSize for boundary computation, not
@@ -113,7 +117,7 @@ internal class KeysetQueryPagingSource<T : Any>(
                         val entities = queryProvider(key, nextKey)
                             .also { currentQuery = it }
                             .executeAsList()
-                        onRowsLoaded(entities)
+                        loadedRows = entities
                         val results = entities.mapNotNull { deserialize(it) }
 
                         if (params.placeholdersEnabled) {
@@ -139,7 +143,13 @@ internal class KeysetQueryPagingSource<T : Any>(
                 }
             val loadResult = transacter
                 .transactionWithResult(body = getPagingSourceLoadResult)
-            if (invalid) PagingSource.LoadResult.Invalid() else loadResult
+            if (invalid) {
+                PagingSource.LoadResult.Invalid()
+            } else {
+                // Mark rows read only for a page that is actually returned to Paging3.
+                loadedRows?.let(onRowsLoaded)
+                loadResult
+            }
         }
     }
 

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/OffsetQueryPagingSource.kt
@@ -38,6 +38,9 @@ internal class OffsetQueryPagingSource<T : Any>(
                 is PagingSource.LoadParams.Prepend<*> -> minOf(key, params.loadSize)
                 else -> params.loadSize
             }
+            // Rows fetched inside the transaction, hoisted so read-tracking runs *after* the
+            // invalid check below — a load discarded as Invalid must not mark rows read (#119).
+            var loadedRows: List<Entity>? = null
             val getPagingSourceLoadResult: SqkonTransactionScope.() -> PagingSource.LoadResult.Page<Int, T> =
                 {
                     val count = totalCount ?: countQuery.executeAsOne().also { totalCount = it }
@@ -53,7 +56,7 @@ internal class OffsetQueryPagingSource<T : Any>(
                     val entities = queryProvider(limit, offset)
                         .also { currentQuery = it }
                         .executeAsList()
-                    onRowsLoaded(entities)
+                    loadedRows = entities
                     val data = entities.mapNotNull { deserialize(it) }
                     val nextPosToLoad = offset + data.size
                     PagingSource.LoadResult.Page(
@@ -66,7 +69,13 @@ internal class OffsetQueryPagingSource<T : Any>(
                 }
             val loadResult = transacter
                 .transactionWithResult(body = getPagingSourceLoadResult)
-            if (invalid) PagingSource.LoadResult.Invalid() else loadResult
+            if (invalid) {
+                PagingSource.LoadResult.Invalid()
+            } else {
+                // Mark rows read only for a page that is actually returned to Paging3.
+                loadedRows?.let(onRowsLoaded)
+                loadResult
+            }
         }
     }
 

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/OffsetPagingTest.kt
@@ -18,6 +18,8 @@ import org.junit.After
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
 
 class OffsetPagingTest {
 
@@ -100,6 +102,27 @@ class OffsetPagingTest {
         // Should refresh
         until { results.size >= 3 }
         assertEquals(3, results.size, "Should have 3 results after invalidation")
+    }
+
+    @Test
+    fun offsetPaging_expiresAfter_countExcludesExpiredRows() = runTest {
+        // Regression: selectPagingSource must apply expiresAfter to the COUNT as well as the
+        // page query. With 10 live + 10 expired rows and a full first page of the 10 live rows,
+        // a count that ignores expiry over-reports (20), leaving a phantom nextKey and 10
+        // trailing placeholders that never resolve.
+        val now = Clock.System.now()
+        val live = (1..10).map { TestObject() }.associateBy { it.id }
+        val expired = (1..10).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(live)
+        testObjectStorage.insertAll(expired, expiresAt = now.minus(1.milliseconds))
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
+        val pager = TestPager(config, testObjectStorage.selectPagingSource(expiresAfter = now))
+
+        val page = pager.refresh() as LoadResult.Page<Int, TestObject>
+        assertEquals(10, page.data.size, "First page should hold only the 10 non-expired rows")
+        assertEquals(0, page.itemsAfter, "Count must exclude expired rows, so nothing follows")
+        assertNull(page.nextKey, "No further page exists once expired rows are excluded")
     }
 
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/PagingReadTrackingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/PagingReadTrackingTest.kt
@@ -1,0 +1,139 @@
+package com.mercury.sqkon.db
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingSource.LoadResult
+import com.mercury.sqkon.TestObject
+import com.mercury.sqkon.db.paging.KeysetQueryPagingSource
+import com.mercury.sqkon.db.paging.OffsetQueryPagingSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for #119: a load that is discarded as [LoadResult.Invalid] (a concurrent
+ * write invalidated it mid-flight) must NOT mark its fetched rows read. Read-tracking is wired
+ * in [KeyValueStorage] via `onRowsLoaded = { updateReadAt(it) }`, so asserting `onRowsLoaded`
+ * does not fire on a discarded page is a direct, deterministic proxy for "read_at not bumped".
+ *
+ * The sources are constructed directly (identity `deserialize`, so the target type is [Entity])
+ * with a spy `onRowsLoaded`, wiring the same [EntityQueries] provider builders that
+ * [KeyValueStorage.selectKeysetPagingSource] / [KeyValueStorage.selectPagingSource] use
+ * internally — the spy is the only substitution, replacing the production `updateReadAt` hook.
+ */
+class PagingReadTrackingTest {
+
+    private val mainScope = MainScope()
+    private val driver = driverFactory().createDriver()
+    private val entityQueries = EntityQueries(driver)
+    private val metadataQueries = MetadataQueries(driver)
+    private val testObjectStorage = keyValueStorage<TestObject>(
+        "test-object", entityQueries, metadataQueries, mainScope
+    )
+
+    @After
+    fun tearDown() {
+        mainScope.cancel()
+    }
+
+    private fun keysetSource(onRowsLoaded: (List<Entity>) -> Unit) =
+        KeysetQueryPagingSource<Entity>(
+            queryProvider = entityQueries.selectKeyed(entityName = ENTITY_NAME),
+            pageBoundariesProvider = entityQueries.selectPageBoundaries(entityName = ENTITY_NAME),
+            boundaryForKeyProvider = entityQueries.selectBoundaryForKey(entityName = ENTITY_NAME),
+            countQuery = entityQueries.count(ENTITY_NAME),
+            transacter = entityQueries,
+            context = Dispatchers.Unconfined,
+            deserialize = { it },
+            pageSize = 10,
+            onRowsLoaded = onRowsLoaded,
+        )
+
+    private fun offsetSource(onRowsLoaded: (List<Entity>) -> Unit) =
+        OffsetQueryPagingSource<Entity>(
+            queryProvider = { limit, offset ->
+                entityQueries.select(ENTITY_NAME, limit = limit.toLong(), offset = offset.toLong())
+            },
+            countQuery = entityQueries.count(ENTITY_NAME),
+            transacter = entityQueries,
+            context = Dispatchers.Unconfined,
+            deserialize = { it },
+            initialOffset = 0,
+            onRowsLoaded = onRowsLoaded,
+        )
+
+    @Test
+    fun keyset_invalidatedLoad_doesNotMarkRowsRead() = runTest {
+        testObjectStorage.insertAll((1..30).map { TestObject() }.associateBy { it.id })
+        var rowsLoadedInvoked = false
+        val source = keysetSource { rowsLoadedInvoked = true }
+
+        source.invalidate() // simulate a concurrent write invalidating the in-flight load
+        val result = source.load(
+            PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
+        )
+
+        assertTrue(result is LoadResult.Invalid, "Invalidated load must be discarded as Invalid")
+        assertFalse(
+            rowsLoadedInvoked,
+            "onRowsLoaded (→ updateReadAt) must not fire for a page discarded as Invalid",
+        )
+    }
+
+    @Test
+    fun keyset_validLoad_marksRowsRead() = runTest {
+        // Guards against over-correcting: a load that is actually returned MUST still
+        // report its rows so read-tracking keeps working.
+        testObjectStorage.insertAll((1..30).map { TestObject() }.associateBy { it.id })
+        var loadedKeys: List<String>? = null
+        val source = keysetSource { entities -> loadedKeys = entities.map { it.entity_key } }
+
+        val result = source.load(
+            PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
+        )
+
+        assertTrue(result is LoadResult.Page, "A non-invalidated load must return a Page")
+        assertEquals(10, loadedKeys?.size, "A returned page must still report its rows to onRowsLoaded")
+    }
+
+    @Test
+    fun offset_invalidatedLoad_doesNotMarkRowsRead() = runTest {
+        testObjectStorage.insertAll((1..30).map { TestObject() }.associateBy { it.id })
+        var rowsLoadedInvoked = false
+        val source = offsetSource { rowsLoadedInvoked = true }
+
+        source.invalidate()
+        val result = source.load(
+            PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
+        )
+
+        assertTrue(result is LoadResult.Invalid, "Invalidated load must be discarded as Invalid")
+        assertFalse(
+            rowsLoadedInvoked,
+            "onRowsLoaded (→ updateReadAt) must not fire for a page discarded as Invalid",
+        )
+    }
+
+    @Test
+    fun offset_validLoad_marksRowsRead() = runTest {
+        testObjectStorage.insertAll((1..30).map { TestObject() }.associateBy { it.id })
+        var loadedKeys: List<String>? = null
+        val source = offsetSource { entities -> loadedKeys = entities.map { it.entity_key } }
+
+        val result = source.load(
+            PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
+        )
+
+        assertTrue(result is LoadResult.Page, "A non-invalidated load must return a Page")
+        assertEquals(10, loadedKeys?.size, "A returned page must still report its rows to onRowsLoaded")
+    }
+
+    private companion object {
+        const val ENTITY_NAME = "test-object"
+    }
+}


### PR DESCRIPTION
## Summary

Two small, independent paging fixes (kept as separate commits).

### 1. `fix(paging): defer read-tracking until after the Invalid check` — Fixes #119

Both paging sources invoked `onRowsLoaded` (wired to `updateReadAt`, which bumps `read_at`) **inside** the load transaction, before the post-transaction `if (invalid)` check. A load invalidated mid-flight — returned to Paging3 as `LoadResult.Invalid` and its data discarded — still marked its rows read, bumping `read_at` on rows the user never saw.

Fix: hoist the fetched rows out of the transaction body and invoke `onRowsLoaded` only in the non-invalid branch, so a discarded page never marks rows read. Empty-boundary keyset loads still skip the hook (no page query ran), preserving prior behaviour for returned pages.

### 2. `fix(paging): apply expiresAfter to offset paging count query`

Found during review of this branch. `selectPagingSource` passed `expiresAfter` to the page query but **not** to the count, so with an expiry filter the cached offset `totalCount` over-reported by the number of expired rows — leaving a phantom `nextKey` and trailing placeholders that never resolve. The keyset source already passed it. One-line fix to match.

## Tests

- New `PagingReadTrackingTest` — for both keyset & offset sources: an invalidated load must not fire `onRowsLoaded`; a returned page still must. (Deterministic: the spy stands in for the async `updateReadAt` hook, which is invoked synchronously inside `load()`.)
- New `OffsetPagingTest.offsetPaging_expiresAfter_countExcludesExpiredRows` — 10 live + 10 expired rows at page size 10; asserts the first full page reports `itemsAfter=0` and `nextKey=null`.
- Both written test-first (verified red → green). Full `./gradlew jvmTest` (incl. the SchemaParity/SchemaMigration gate) passes.

## Notes

- Two distinct `fix:` commits — a **merge** (not squash) keeps both changelog entries for release-please.
- Not addressed here (documented tradeoff): keyset `COUNT(DISTINCT entity_key)` vs. raw `json_tree`-multiplied boundary rows can skew `itemsBefore/itemsAfter` on a multiplying `where` — the known #68 raw-row over-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
