### PR TITLE
fix(paging): honor initialLoadSize on keyset refresh to stop placeholder blink

### DIFF
--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -112,7 +112,17 @@ internal class KeysetQueryPagingSource<T : Any>(
                         }
                         val key = boundaries[keyIndex]
                         val previousKey = boundaries.getOrNull(keyIndex - 1)
-                        val nextKey = boundaries.getOrNull(keyIndex + 1)
+                        // Load enough whole pages to satisfy params.loadSize. On REFRESH
+                        // Paging requests initialLoadSize (typically 3 * pageSize) so the
+                        // previously-visible window repopulates in one atomic page; loading a
+                        // single page here would blink the off-anchor visible rows to
+                        // placeholders until follow-up prefetch APPEND/PREPEND refills them
+                        // (#128). APPEND/PREPEND use loadSize == pageSize, so this loads one
+                        // page for them — unchanged behaviour. nextKey is the boundary past the
+                        // loaded window so the next APPEND resumes exactly where this ends.
+                        val pageCount = ((params.loadSize + pageSize - 1) / pageSize)
+                            .coerceAtLeast(1)
+                        val nextKey = boundaries.getOrNull(keyIndex + pageCount)
 
                         val entities = queryProvider(key, nextKey)
                             .also { currentQuery = it }

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -187,11 +187,16 @@ internal class KeysetQueryPagingSource<T : Any>(
 
         // First loaded page: its own load key is not recoverable from state, and it
         // may span several pageSize pages (a refresh window honoring initialLoadSize).
-        // The known boundary keys around it are prevKey (one page before its start),
-        // pages[1].prevKey (one page before its end), and nextKey (its end). Locate
-        // the pageSize page containing the anchor and return whichever known key's
-        // centered refresh window is guaranteed — or, for a lone multi-page window's
-        // uncovered middle, closest — to cover the anchor's page.
+        // The only keys state still holds sit at known sub-pages of this page's
+        // window (pageSpan = 3 shown):
+        //
+        //   sub-page:   -1    |   0      1      2   |    3
+        //   key:      prevKey | [--- this page ---] |  nextKey
+        //                                       ^ pages[1].prevKey = sub-page 2
+        //
+        // A refresh from a key at sub-page k loads windowPages pages starting
+        // backReach pages before k (load()'s centering, mirrored). Find the anchor's
+        // sub-page and return the key whose window covers it.
         if (anchorPage.data.isEmpty()) return anchorPage.prevKey
         val pageSpan = pagesFor(anchorPage.data.size)
         val leadingPlaceholders = anchorPage.itemsBefore
@@ -200,17 +205,19 @@ internal class KeysetQueryPagingSource<T : Any>(
             .coerceIn(0, anchorPage.data.size - 1) / pageSize
         val windowPages = pagesFor(state.config.initialLoadSize)
         val backReach = windowBackShift(windowPages)
-        // A refresh from a key at sub-page k loads windowPages pages starting
-        // backReach pages before k — load()'s centering, mirrored.
         fun windowFromKeyAtCoversAnchor(keySubPage: Int): Boolean =
             subPage >= keySubPage - backReach &&
                 subPage < keySubPage - backReach + windowPages
+
+        // The late-side candidate: pages[1].prevKey when a next page exists (one page
+        // before this page's end), else this page's own nextKey (its end).
         val nextPage = state.pages.getOrNull(anchorIndex + 1)
+        val (lateKey, lateKeySubPage) = when {
+            nextPage != null -> nextPage.prevKey to pageSpan - 1
+            else -> anchorPage.nextKey to pageSpan
+        }
         return when {
-            // pages[1].prevKey sits one page before this page's end (sub-page pageSpan-1).
-            nextPage != null && windowFromKeyAtCoversAnchor(pageSpan - 1) -> nextPage.prevKey
-            // Lone page: nextKey sits at this page's end (sub-page pageSpan).
-            nextPage == null && windowFromKeyAtCoversAnchor(pageSpan) -> anchorPage.nextKey
+            windowFromKeyAtCoversAnchor(lateKeySubPage) -> lateKey
             // prevKey sits at sub-page -1 — covers early sub-pages, and is the closest
             // fallback when nothing covers (a lone multi-page window's middle). null
             // means the page starts at boundaries.first(), and load(null) preserves that.

--- a/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
+++ b/library/src/commonMain/kotlin/com/mercury/sqkon/db/paging/KeysetQueryPagingSource.kt
@@ -55,6 +55,16 @@ internal class KeysetQueryPagingSource<T : Any>(
 
     override val jumpingSupported: Boolean get() = false
 
+    /** Whole pageSize pages needed to cover [rows] rows (ceil division). */
+    private fun pagesFor(rows: Int): Int = (rows + pageSize - 1) / pageSize
+
+    /**
+     * Pages the load window extends *behind* the requested page — the centering shift.
+     * [load] and [getRefreshKey] must agree on this geometry: getRefreshKey picks a key
+     * assuming exactly this window placement will cover the anchor.
+     */
+    private fun windowBackShift(pageCount: Int): Int = (pageCount - 1) / 2
+
     override suspend fun load(
         params: PagingSource.LoadParams<String>,
     ): PagingSource.LoadResult<String, T> = withContext(context) {
@@ -110,30 +120,29 @@ internal class KeysetQueryPagingSource<T : Any>(
                                 }
                             }
                         }
-                        val key = boundaries[keyIndex]
-                        val previousKey = boundaries.getOrNull(keyIndex - 1)
-                        // Load enough whole pages to satisfy params.loadSize. On REFRESH
-                        // Paging requests initialLoadSize (typically 3 * pageSize) so the
-                        // previously-visible window repopulates in one atomic page; loading a
-                        // single page here would blink the off-anchor visible rows to
-                        // placeholders until follow-up prefetch APPEND/PREPEND refills them
-                        // (#128). APPEND/PREPEND use loadSize == pageSize, so this loads one
-                        // page for them — unchanged behaviour. nextKey is the boundary past the
-                        // loaded window so the next APPEND resumes exactly where this ends.
-                        val pageCount = ((params.loadSize + pageSize - 1) / pageSize)
-                            .coerceAtLeast(1)
-                        val nextKey = boundaries.getOrNull(keyIndex + pageCount)
+                        // Load enough whole pages for params.loadSize, centered on the
+                        // requested page, so a REFRESH (loadSize = initialLoadSize)
+                        // repopulates the visible window around the anchor in one atomic
+                        // page instead of blinking off-anchor rows to placeholders (#128).
+                        // APPEND/PREPEND pass loadSize == pageSize: one page, no shift.
+                        val pageCount = pagesFor(params.loadSize)
+                        val startIndex = (keyIndex - windowBackShift(pageCount))
+                            .coerceAtLeast(0)
+                        val startKey = boundaries[startIndex]
+                        val previousKey = boundaries.getOrNull(startIndex - 1)
+                        val nextKey = boundaries.getOrNull(startIndex + pageCount)
 
-                        val entities = queryProvider(key, nextKey)
+                        val entities = queryProvider(startKey, nextKey)
                             .also { currentQuery = it }
                             .executeAsList()
                         loadedRows = entities
                         val results = entities.mapNotNull { deserialize(it) }
 
                         if (params.placeholdersEnabled) {
-                            // Boundaries sit every pageSize rows, so page keyIndex starts at row
-                            // keyIndex * pageSize; coerce guards boundary/count skew.
-                            val itemsBefore = (keyIndex * pageSize).coerceAtMost(totalCount)
+                            // Boundaries sit every pageSize rows, so the window starting at
+                            // startIndex begins at row startIndex * pageSize; coerce guards
+                            // boundary/count skew.
+                            val itemsBefore = (startIndex * pageSize).coerceAtMost(totalCount)
                             PagingSource.LoadResult.Page(
                                 data = results,
                                 prevKey = previousKey,
@@ -165,20 +174,47 @@ internal class KeysetQueryPagingSource<T : Any>(
 
     override fun getRefreshKey(state: PagingState<String, T>): String? {
         // Must derive from state, not the instance's pageBoundaries — Paging3
-        // calls this on a fresh source before its first load(). Our keys are
-        // page-start boundaries, so the anchor page's own load key equals
-        // pages[i+1].prevKey (or pages[i-1].nextKey); using anchorPage.prevKey
-        // /nextKey directly would shift the user by one full page.
+        // calls this on a fresh source before its first load(). Pages are
+        // contiguous, so any page loaded after another has its exact load key in
+        // the preceding page's nextKey — regardless of how many pageSize pages
+        // either spans. (pages[i+1].prevKey is NOT equivalent: for a multi-page
+        // refresh window it sits pageCount-1 pages past the window start, which
+        // would drop the anchor and reintroduce the #128 blink.)
         val anchorPosition = state.anchorPosition ?: return null
         val anchorPage = state.closestPageToPosition(anchorPosition) ?: return null
         val anchorIndex = state.pages.indexOf(anchorPage)
-        state.pages.getOrNull(anchorIndex + 1)?.let { return it.prevKey }
         state.pages.getOrNull(anchorIndex - 1)?.let { return it.nextKey }
-        // Single loaded page: prevKey is the boundary *before* this page (the closest
-        // hint to the anchor's location); null means the anchor is in the first page,
-        // and our load(null) resolves to boundaries.first() — preserving the anchor.
-        // Do not fall back to nextKey: that points to the *next* page's start, which
-        // would load past the anchor row and shift it off-screen.
-        return anchorPage.prevKey
+
+        // First loaded page: its own load key is not recoverable from state, and it
+        // may span several pageSize pages (a refresh window honoring initialLoadSize).
+        // The known boundary keys around it are prevKey (one page before its start),
+        // pages[1].prevKey (one page before its end), and nextKey (its end). Locate
+        // the pageSize page containing the anchor and return whichever known key's
+        // centered refresh window is guaranteed — or, for a lone multi-page window's
+        // uncovered middle, closest — to cover the anchor's page.
+        if (anchorPage.data.isEmpty()) return anchorPage.prevKey
+        val pageSpan = pagesFor(anchorPage.data.size)
+        val leadingPlaceholders = anchorPage.itemsBefore
+            .takeIf { it != PagingSource.LoadResult.Page.COUNT_UNDEFINED } ?: 0
+        val subPage = (anchorPosition - leadingPlaceholders)
+            .coerceIn(0, anchorPage.data.size - 1) / pageSize
+        val windowPages = pagesFor(state.config.initialLoadSize)
+        val backReach = windowBackShift(windowPages)
+        // A refresh from a key at sub-page k loads windowPages pages starting
+        // backReach pages before k — load()'s centering, mirrored.
+        fun windowFromKeyAtCoversAnchor(keySubPage: Int): Boolean =
+            subPage >= keySubPage - backReach &&
+                subPage < keySubPage - backReach + windowPages
+        val nextPage = state.pages.getOrNull(anchorIndex + 1)
+        return when {
+            // pages[1].prevKey sits one page before this page's end (sub-page pageSpan-1).
+            nextPage != null && windowFromKeyAtCoversAnchor(pageSpan - 1) -> nextPage.prevKey
+            // Lone page: nextKey sits at this page's end (sub-page pageSpan).
+            nextPage == null && windowFromKeyAtCoversAnchor(pageSpan) -> anchorPage.nextKey
+            // prevKey sits at sub-page -1 — covers early sub-pages, and is the closest
+            // fallback when nothing covers (a lone multi-page window's middle). null
+            // means the page starts at boundaries.first(), and load(null) preserves that.
+            else -> anchorPage.prevKey
+        }
     }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
@@ -506,4 +506,68 @@ class KeysetPagingTest {
             "itemsBefore + loaded + itemsAfter must equal the full dataset count",
         )
     }
+
+    @Test
+    fun keysetPaging_refresh_honorsInitialLoadSize() = runTest {
+        // Regression #128: on REFRESH Paging3 requests initialLoadSize rows (its
+        // default is 3 * pageSize) so the previously-visible window repopulates in a
+        // single atomic page. A source that ignores params.loadSize and returns only
+        // one pageSize page leaves the off-anchor visible rows as placeholders until
+        // follow-up prefetch APPEND/PREPEND loads refill them — the "blink to skeleton
+        // and back" reported on RemoteMediator appends. All other keyset tests set
+        // initialLoadSize == pageSize, which masks this.
+        val expected = (1..100).map { TestObject() }.associateBy { it.id }
+        testObjectStorage.insertAll(expected)
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 30)
+        val pager = TestPager(config, testObjectStorage.selectKeysetPagingSource(pageSize = 10))
+
+        val result = pager.refresh() as LoadResult.Page<String, TestObject>
+        assertEquals(
+            30, result.data.size,
+            "Refresh must honor initialLoadSize (30) so the visible window loads " +
+                "atomically instead of blinking off-anchor rows to placeholders"
+        )
+        assertNull(result.prevKey, "Prev key should be null for the first window")
+        assertNotNull(result.nextKey, "Next key should point past the 3-page window")
+    }
+
+    @Test
+    fun keysetPaging_mediatorWrite_refreshLoadsFullVisibleWindow() = runTest {
+        // Regression #128 end-to-end: user has scrolled a 3-page (initialLoadSize=30)
+        // window into view, a mediator-style append invalidates + shifts boundaries,
+        // and the fresh source's REFRESH must repopulate the WHOLE visible window in
+        // one page (not just the anchor page) so no on-screen row flashes a placeholder.
+        val initial = (1..50).associate { i ->
+            val id = "key-${i.toString().padStart(3, '0')}"
+            id to TestObject(id = id, value = i)
+        }
+        testObjectStorage.insertAll(initial)
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 30)
+        val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val pagerA = TestPager(config, sourceA)
+        // Refresh loads the first 30 (rn 1..30) as one window.
+        with(pagerA) { refresh(); append() } // + rn 31..40 visible
+        val state = pagerA.getPagingState(anchorPosition = 15)
+
+        val injected = (1..5).associate { i ->
+            val id = "key-005-injected-$i"
+            id to TestObject(id = id, value = 100 + i)
+        }
+        testObjectStorage.insertAll(injected)
+
+        val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val refreshKey = sourceB.getRefreshKey(state)
+        val page = sourceB.load(
+            PagingSource.LoadParams.Refresh(
+                key = refreshKey, loadSize = 30, placeholdersEnabled = true,
+            )
+        ) as LoadResult.Page<String, TestObject>
+
+        assertEquals(
+            30, page.data.size,
+            "Refresh must repopulate the full 3-page visible window, not just the anchor page"
+        )
+    }
 }

--- a/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
+++ b/library/src/commonTest/kotlin/com/mercury/sqkon/db/KeysetPagingTest.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadResult
+import androidx.paging.PagingState
 import androidx.paging.testing.TestPager
 import androidx.paging.testing.asSnapshot
 import com.mercury.sqkon.TestObject
@@ -35,6 +36,36 @@ class KeysetPagingTest {
     @After
     fun tearDown() {
         mainScope.cancel()
+    }
+
+    /** Deterministic rows: keys "key-001".."key-NNN" sort in insertion order. */
+    private fun paddedRows(range: IntRange = 1..50) = range.associate { i ->
+        val id = "key-${i.toString().padStart(3, '0')}"
+        id to TestObject(id = id, value = i)
+    }
+
+    /** Mediator-style write: 5 keys sorting between "key-005" and "key-006". */
+    private suspend fun injectMediatorRows() = testObjectStorage.insertAll(
+        (1..5).associate { i ->
+            val id = "key-005-injected-$i"
+            id to TestObject(id = id, value = 100 + i)
+        }
+    )
+
+    /** Fresh source refreshed from [state]'s refresh key; returns the loaded page. */
+    private suspend fun refreshFromState(
+        state: PagingState<String, TestObject>,
+        loadSize: Int,
+        placeholdersEnabled: Boolean = true,
+    ): LoadResult.Page<String, TestObject> {
+        val source = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        return source.load(
+            PagingSource.LoadParams.Refresh(
+                key = source.getRefreshKey(state),
+                loadSize = loadSize,
+                placeholdersEnabled = placeholdersEnabled,
+            )
+        ) as LoadResult.Page<String, TestObject>
     }
 
     @Test
@@ -283,11 +314,7 @@ class KeysetPagingTest {
         //      "key-016", "key-026". "key-011" is no longer a boundary.
         //   4. load(params.key = "key-011") MUST snap to "key-006" (page containing it),
         //      NOT throw `Key key-011 not found in page boundaries`.
-        val initial = (1..30).associate { i ->
-            val id = "key-${i.toString().padStart(3, '0')}"
-            id to TestObject(id = id, value = i)
-        }
-        testObjectStorage.insertAll(initial)
+        testObjectStorage.insertAll(paddedRows(1..30))
 
         val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
         val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
@@ -295,11 +322,7 @@ class KeysetPagingTest {
         with(pagerA) { refresh(); append() } // 2 pages loaded
         val state = pagerA.getPagingState(anchorPosition = 15)
 
-        val injected = (1..5).associate { i ->
-            val id = "key-005-injected-$i"
-            id to TestObject(id = id, value = 100 + i)
-        }
-        testObjectStorage.insertAll(injected)
+        injectMediatorRows()
 
         val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
         val staleRefreshKey = sourceB.getRefreshKey(state)
@@ -326,11 +349,7 @@ class KeysetPagingTest {
     fun keysetPaging_mediatorWriteDuringLoad_preservesAnchorPage() = runTest {
         // End-to-end regression: user scrolls to the 3rd page, mediator-style write
         // shifts boundaries, fresh source resumes near the anchor (not page 0).
-        val initial = (1..50).associate { i ->
-            val id = "key-${i.toString().padStart(3, '0')}"
-            id to TestObject(id = id, value = i)
-        }
-        testObjectStorage.insertAll(initial)
+        testObjectStorage.insertAll(paddedRows())
 
         val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
         val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
@@ -338,11 +357,7 @@ class KeysetPagingTest {
         with(pagerA) { refresh(); append(); append() } // 3 pages: key-001..key-030
         val state = pagerA.getPagingState(anchorPosition = 25)
 
-        val injected = (1..5).associate { i ->
-            val id = "key-005-injected-$i"
-            id to TestObject(id = id, value = 100 + i)
-        }
-        testObjectStorage.insertAll(injected)
+        injectMediatorRows()
 
         val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
         val refreshKey = sourceB.getRefreshKey(state)
@@ -473,11 +488,7 @@ class KeysetPagingTest {
         // Same fixture as keysetPaging_mediatorWriteDuringLoad_preservesAnchorPage:
         // 50 rows + 5 injected = 55; anchor 25 snaps to the boundary at rn=21
         // ("key-016") = the 3rd page = absolute offset 20.
-        val initial = (1..50).associate { i ->
-            val id = "key-${i.toString().padStart(3, '0')}"
-            id to TestObject(id = id, value = i)
-        }
-        testObjectStorage.insertAll(initial)
+        testObjectStorage.insertAll(paddedRows())
 
         val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 10)
         val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
@@ -485,19 +496,9 @@ class KeysetPagingTest {
         with(pagerA) { refresh(); append(); append() }
         val state = pagerA.getPagingState(anchorPosition = 25)
 
-        val injected = (1..5).associate { i ->
-            val id = "key-005-injected-$i"
-            id to TestObject(id = id, value = 100 + i)
-        }
-        testObjectStorage.insertAll(injected)
+        injectMediatorRows()
 
-        val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
-        val refreshKey = sourceB.getRefreshKey(state)
-        val page = sourceB.load(
-            PagingSource.LoadParams.Refresh(
-                key = refreshKey, loadSize = 10, placeholdersEnabled = true,
-            )
-        ) as LoadResult.Page<String, TestObject>
+        val page = refreshFromState(state, loadSize = 10)
 
         assertEquals("key-016", page.data.first().id, "Fixture invariant: snaps to page-3 boundary")
         assertEquals(20, page.itemsBefore, "Refreshed page must report its absolute offset (20)")
@@ -509,12 +510,8 @@ class KeysetPagingTest {
 
     @Test
     fun keysetPaging_refresh_honorsInitialLoadSize() = runTest {
-        // Regression #128: on REFRESH Paging3 requests initialLoadSize rows (its
-        // default is 3 * pageSize) so the previously-visible window repopulates in a
-        // single atomic page. A source that ignores params.loadSize and returns only
-        // one pageSize page leaves the off-anchor visible rows as placeholders until
-        // follow-up prefetch APPEND/PREPEND loads refill them — the "blink to skeleton
-        // and back" reported on RemoteMediator appends. All other keyset tests set
+        // Regression #128: REFRESH must return the full initialLoadSize window in one
+        // atomic page (see KeysetQueryPagingSource.load). Other keyset tests set
         // initialLoadSize == pageSize, which masks this.
         val expected = (1..100).map { TestObject() }.associateBy { it.id }
         testObjectStorage.insertAll(expected)
@@ -534,40 +531,81 @@ class KeysetPagingTest {
 
     @Test
     fun keysetPaging_mediatorWrite_refreshLoadsFullVisibleWindow() = runTest {
-        // Regression #128 end-to-end: user has scrolled a 3-page (initialLoadSize=30)
-        // window into view, a mediator-style append invalidates + shifts boundaries,
-        // and the fresh source's REFRESH must repopulate the WHOLE visible window in
-        // one page (not just the anchor page) so no on-screen row flashes a placeholder.
-        val initial = (1..50).associate { i ->
-            val id = "key-${i.toString().padStart(3, '0')}"
-            id to TestObject(id = id, value = i)
-        }
-        testObjectStorage.insertAll(initial)
+        // Regression #128 end-to-end: a mediator-style append invalidates + shifts
+        // boundaries; the fresh source's REFRESH must repopulate the whole visible
+        // window in one page so no on-screen row flashes a placeholder.
+        testObjectStorage.insertAll(paddedRows())
 
         val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 30)
         val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
         val pagerA = TestPager(config, sourceA)
-        // Refresh loads the first 30 (rn 1..30) as one window.
-        with(pagerA) { refresh(); append() } // + rn 31..40 visible
+        // Refresh loads the first 30 (rn 1..30) as one window, append adds rn 31..40.
+        with(pagerA) { refresh(); append() }
         val state = pagerA.getPagingState(anchorPosition = 15)
 
-        val injected = (1..5).associate { i ->
-            val id = "key-005-injected-$i"
-            id to TestObject(id = id, value = 100 + i)
-        }
-        testObjectStorage.insertAll(injected)
+        injectMediatorRows()
 
-        val sourceB = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
-        val refreshKey = sourceB.getRefreshKey(state)
-        val page = sourceB.load(
-            PagingSource.LoadParams.Refresh(
-                key = refreshKey, loadSize = 30, placeholdersEnabled = true,
-            )
-        ) as LoadResult.Page<String, TestObject>
+        val page = refreshFromState(state, loadSize = 30)
 
         assertEquals(
             30, page.data.size,
             "Refresh must repopulate the full 3-page visible window, not just the anchor page"
         )
+        assertTrue(
+            page.data.any { it.id == "key-016" },
+            "Refreshed window must contain the anchor row (key-016, anchorPosition 15) — " +
+                "size alone can pass while the window is mis-anchored pages forward"
+        )
+    }
+
+    @Test
+    fun keysetPaging_getRefreshKey_anchorInMultiPageRefreshWindow_keepsAnchor() = runTest {
+        // Regression: with initialLoadSize=30 the refresh page spans 3 boundaries, so
+        // the old pages[i+1].prevKey derivation returned a boundary 2 pages past the
+        // window start — the next generation's refresh dropped the anchor row.
+        testObjectStorage.insertAll(paddedRows())
+
+        val config = PagingConfig(pageSize = 10, prefetchDistance = 0, initialLoadSize = 30)
+        val sourceA = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val pagerA = TestPager(config, sourceA)
+        with(pagerA) { refresh(); append() } // 30-row refresh page + 10-row append
+
+        // Anchor mid-window (row 16, sub-page 1 of the 3-page refresh page).
+        val midPage = refreshFromState(pagerA.getPagingState(anchorPosition = 15), loadSize = 30)
+        assertTrue(
+            midPage.data.any { it.id == "key-016" },
+            "Refresh window must contain the mid-window anchor row"
+        )
+
+        // Anchor early in the window (row 6, sub-page 0).
+        val earlyPage = refreshFromState(pagerA.getPagingState(anchorPosition = 5), loadSize = 30)
+        assertTrue(
+            earlyPage.data.any { it.id == "key-006" },
+            "Refresh window must contain the early-window anchor row"
+        )
+    }
+
+    @Test
+    fun keysetPaging_refresh_centersWindowOnRequestedPage() = runTest {
+        // The visible viewport extends both ways from the anchor page, so a
+        // multi-page refresh must load pages before the requested page too (#128).
+        testObjectStorage.insertAll(paddedRows())
+
+        val source = testObjectStorage.selectKeysetPagingSource(pageSize = 10)
+        val page = source.load(
+            PagingSource.LoadParams.Refresh(
+                key = "key-021", loadSize = 30, placeholdersEnabled = true,
+            )
+        ) as LoadResult.Page<String, TestObject>
+
+        assertEquals(30, page.data.size)
+        assertEquals(
+            "key-011", page.data.first().id,
+            "Window must start one page above the requested page (centered), not at it"
+        )
+        assertTrue(page.data.any { it.id == "key-021" }, "Window must contain the requested page")
+        assertEquals(10, page.itemsBefore, "Absolute offset must reflect the centered start")
+        assertEquals("key-001", page.prevKey, "Prepend resumes at the boundary before the window")
+        assertEquals("key-041", page.nextKey, "Append resumes at the boundary after the window")
     }
 }


### PR DESCRIPTION
## Summary

Fixes #128 — keyset `PagingSource` blinks visible rows to placeholders on RemoteMediator-append invalidation.

`KeysetQueryPagingSource` ignored `params.loadSize` and always loaded exactly **one** `pageSize` page — even on `REFRESH`, where Paging3 requests `initialLoadSize` (default `3 * pageSize`) so the previously-visible window repopulates in a single atomic page. After a RemoteMediator-append invalidation, the fresh source's refresh returned only the anchor page, so every other on-screen row became a placeholder and flashed its skeleton until follow-up prefetch `APPEND`/`PREPEND` loads refilled it. (The offset source already honors `params.loadSize`; the keyset source did not.)

## Fix

- **`load()`** loads `ceil(loadSize / pageSize)` whole pages, **centered on the requested page** — the viewport extends both ways from the anchor page, so the window must reload rows above it too, not just forward. `APPEND`/`PREPEND` pass `loadSize == pageSize` → one page, zero shift: unchanged.
- **`getRefreshKey()`** reworked for multi-boundary pages: the exact load key comes from the *preceding* page's `nextKey` (contiguity holds for any page span; the previous `pages[i+1].prevKey` derivation sits `pageCount-1` pages past a multi-page window's start and would drop the anchor). For the first loaded page — whose own load key is unrecoverable from state — it locates the anchor's sub-page and returns the known boundary key (`prevKey` / `pages[1].prevKey` / `nextKey`) whose centered window covers it.
- Window geometry lives in shared `pagesFor`/`windowBackShift` helpers used by both methods, so they can't silently drift apart.
- Boundary computation still uses the stable `pageSize`; `itemsBefore`/`itemsAfter` (absolute positions from #117) reflect the centered window start.

## Regression tests

Every existing keyset test set `initialLoadSize == pageSize`, which masked the bug. New tests (all fail before the fix):

- `keysetPaging_refresh_honorsInitialLoadSize` — refresh returns the full 30-row window, not 10.
- `keysetPaging_mediatorWrite_refreshLoadsFullVisibleWindow` — after a mediator-style write shifts boundaries, refresh repopulates the whole visible window **and still contains the anchor row**.
- `keysetPaging_getRefreshKey_anchorInMultiPageRefreshWindow_keepsAnchor` — anchor inside a 3-page refresh window survives the next generation's refresh (mid- and early-window anchors).
- `keysetPaging_refresh_centersWindowOnRequestedPage` — the window starts one page above the requested page, with correct `itemsBefore`/`prevKey`/`nextKey`.

Test fixtures shared via `paddedRows`/`injectMediatorRows`/`refreshFromState` helpers (the mediator fixture was previously inlined six times).

## Review

Ran the workflow-backed /code-review (high) + /simplify passes: the review caught that the initial forward-only, single-predicate-free version broke `getRefreshKey`'s anchor guarantee — fixed as above; simplify findings (shared geometry helpers, unified coverage predicate, dead coerce, fixture dedup) applied.

## Verification

`./gradlew jvmTest` — full suite passes. KeysetPagingTest: 20 tests, 0 failures (16 pre-existing + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)